### PR TITLE
update cmake to correctly support computecpp community edition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,83 +6,22 @@ enable_testing()
 option(PARALLEL_STL_BENCHMARKS "Build the internal benchmarks" OFF)
 
 message(STATUS " Path to SYCL implementation: ${COMPUTECPP_PACKAGE_ROOT_DIR} ")
-
-if(SYCL_NO_DEVICE_COMPILER)
-  message(NOTE "The SYCL implementation has no device compiler")
-  add_definitions(-DSYCL_NO_DEVICE_COMPILER=1)
-else(SYCL_NO_DEVICE_COMPILER)
-  #####  Find the SYCL implementation
-
-  find_library(SYCL_LIBRARY
-    NAMES SYCL SYCL_d
-    HINTS ${COMPUTECPP_PACKAGE_ROOT_DIR}
-    PATH_SUFFIXES lib
-    )
-
-  find_library(OPENCL_LIBRARY
-    NAMES OpenCL
-    HINTS ${OPENCL_ROOT_DIR}
-    PATH_SUFFIXES lib lib64
-    )
-
-  if(NOT DEFINED OPENCL_LIBRARY)
-    message(FATAL_ERROR "OpenCL library is not defined")
-  endif()
-
-  message(STATUS "${SYCL_LIBRARY}")
-  if (${SYCL_LIBRARY} MATCHES "NOTFOUND")
-    message(FATAL_ERROR "Cannot find SYCL implementation (${COMPUTECPP_PACKAGE_ROOT_DIR})")
-  else()
-    message(STATUS "The path to SYCL is: ${COMPUTECPP_PACKAGE_ROOT_DIR}")
-  endif()
-
-  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+message(STATUS " Path to CMAKE source directory: ${CMAKE_SOURCE_DIR} ")
 
 
-  set(DEVICE_COMPILER_PATH "${COMPUTECPP_PACKAGE_ROOT_DIR}/bin/")
-  set(DEVICE_COMPILER_INCLUDE_PATH "${COMPUTECPP_PACKAGE_ROOT_DIR}/include/device_compiler")
-  set(RUNTIME_INCLUDES "${COMPUTECPP_PACKAGE_ROOT_DIR}/include")
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules/)
 
-  if (UNIX)
-      # TODO(Ruyman) Figure out the linux distribution
-      # Fix for device compiler not finding specific C++ headers with Ubuntu
-      set(CMAKE_INCLUDE_PATH "${CMAKE_INCLUDE_PATH}"
-                         "/usr/include/c++/4.8.2/"
-                          "/usr/include/x86_64-linux-gnu/c++/4.8/")
-  endif()
+include(FindOpenCL)
+include(FindComputeCpp)
 
-  if (NOT DEFINED DEVICE_COMPILER_NAME)
-    if (WIN32)
-      set(DEVICE_COMPILER_NAME "compute++.exe")
-    else(WIN32)
-      set(DEVICE_COMPILER_NAME "compute++")
-    endif(WIN32)
-  endif (NOT DEFINED DEVICE_COMPILER_NAME)
-  set(DEVICE_COMPILER "${DEVICE_COMPILER_PATH}/${DEVICE_COMPILER_NAME}"
-    CACHE FILEPATH "device compiler")
-  message(STATUS "### Device Compiler ${DEVICE_COMPILER}")
-  add_custom_target(compiler)
+include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
+include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}/image_library")
 
-  # set(COMPUTECPP_PACKAGE_ROOT_DIR ${COMPUTECPP_PACKAGE_ROOT_DIR})
-  set(OpenCL_INCLUDE_DIR ${COMPUTECPP_PACKAGE_ROOT_DIR}/include/CL/)
-  include(FindComputeCpp)
-  set(HOST_COMPILER_OPTIONS -O3 -std=c++11)
-
-  add_library(SYCL_LIBRARY SHARED IMPORTED)
-  add_library(OPENCL_LIBRARY SHARED IMPORTED)
-
-endif(SYCL_NO_DEVICE_COMPILER)
-
-include_directories("${COMPUTECPP_PACKAGE_ROOT_DIR}/include")
-include_directories("${COMPUTECPP_PACKAGE_ROOT_DIR}/include/image_library")
-
-# Build the parallel stl
-
+# PSTL specific 
 include_directories("include")
 
 add_subdirectory (src)
 add_subdirectory (examples)
-
 add_subdirectory (tests)
 
 if (PARALLEL_STL_BENCHMARKS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ include(FindOpenCL)
 include(FindComputeCpp)
 
 include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
-include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}/image_library")
 
 # PSTL specific 
 include_directories("include")

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-# the path to the sycl sdk, e.g. ~/computecpp-sdk/
-SDK_PATH=$1
-# the path to the ComputeCPP package root directory, e.g. ~/ComputeCPP-16.07-Linux/
-PACKAGE_ROOT=$2
+# the path to the ComputeCPP package root directory, e.g. /home/user/ComputeCpp-CE-0.1-Linux/
+PACKAGE_ROOT=$1
 
 function install_gmock  {
   mkdir -p external && pushd external
+  git clone git@github.com:google/googletest.git
   pushd googletest/googlemock/make && make
   popd 
   popd
@@ -13,12 +12,12 @@ function install_gmock  {
 
 function configure  {
   mkdir -p build && pushd build 
-  cmake .. -DCMAKE_MODULE_PATH=$SDK_PATH/cmake/Modules/ -DCOMPUTECPP_PACKAGE_ROOT_DIR=$PACKAGE_ROOT -DSYCL_PATH=$PACKAGE_ROOT -DOpenCL_INCLUDE_DIR=$PACKAGE_ROOT/include/CL/
+  cmake .. -DCOMPUTECPP_PACKAGE_ROOT_DIR=$PACKAGE_ROOT  -DPARALLEL_STL_BENCHMARKS=ON
   popd
 }
 
 function mak  {
-  pushd build && make 
+  pushd build && make -j32
   popd
 }
 

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -1,6 +1,21 @@
 #.rst:
 # FindComputeCpp
 #---------------
+#
+#   Copyright 2016 Codeplay Software Ltd.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use these files except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 #########################
 #  FindComputeCpp.cmake  
@@ -8,6 +23,11 @@
 #
 #  Tools for finding and building with ComputeCpp.
 #
+#  User must define COMPUTECPP_PACKAGE_ROOT_DIR pointing to the ComputeCpp 
+#   installation.
+#  
+#  Latest version of this file can be found at:
+#    https://github.com/codeplaysoftware/computecpp-sdk
 
 # Require CMake version 3.2.2 or higher
 cmake_minimum_required(VERSION 3.2.2)
@@ -68,7 +88,7 @@ endif()
 
 # Obtain the path to computecpp_info
 find_program(COMPUTECPP_INFO_TOOL computecpp_info PATHS
-  ${COMPUTECPP_PACKAGE_ROOT_DIR} PATH_SUFFIXES tools/computecpp_info)
+  ${COMPUTECPP_PACKAGE_ROOT_DIR} PATH_SUFFIXES bin)
 if (EXISTS ${COMPUTECPP_INFO_TOOL})
   mark_as_advanced(${COMPUTECPP_INFO_TOOL})
   message(STATUS "computecpp_info - Found")
@@ -76,8 +96,8 @@ else()
   message(FATAL_ERROR "computecpp_info - Not found! (${COMPUTECPP_INFO_TOOL})")
 endif()
 
-# Obtain the path to the SYCL runtime library
-find_library(COMPUTECPP_RUNTIME_LIBRARY SYCL PATHS ${COMPUTECPP_PACKAGE_ROOT_DIR}
+# Obtain the path to the ComputeCpp runtime library
+find_library(COMPUTECPP_RUNTIME_LIBRARY ComputeCpp PATHS ${COMPUTECPP_PACKAGE_ROOT_DIR}
   HINTS ${COMPUTECPP_PACKAGE_ROOT_DIR}/lib PATH_SUFFIXES lib
   DOC "ComputeCpp Runtime Library" NO_DEFAULT_PATH)
 
@@ -174,7 +194,7 @@ function(__build_spir targetName sourceFile binaryDir)
     OUTPUT ${outputSyclFile}
     COMMAND ${COMPUTECPP_DEVICE_COMPILER}
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            -I${COMPUTECPP_INCLUDE_DIRECTORY}
+            -isystem ${COMPUTECPP_INCLUDE_DIRECTORY}
             ${COMPUTECPP_PLATFORM_SPECIFIC_ARGS}
             ${device_compiler_includes}
             -o ${outputSyclFile}


### PR DESCRIPTION
I missed some changes to the way ComputeCPP's cmake configuration worked around the time of the community edition lauched. These have now been fixed, and the sycl parallel stl should now build correctly with the ComputeCPP community edition.