### PR TITLE
Add CLI benchmark device selector

### DIFF
--- a/benchmarks/basic.cpp
+++ b/benchmarks/basic.cpp
@@ -39,7 +39,8 @@
 using namespace sycl::helpers;
 
 benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
-                                         const unsigned num_elems) {
+                                         const unsigned num_elems,
+                                         const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -47,7 +48,7 @@ benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
   }
 
   auto mysort = [&]() {
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class SortAlgorithm1> snp(q);
     std::experimental::parallel::sort(snp, begin(v1), end(v1));
   };

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -70,8 +70,6 @@ struct benchmark_arguments {
     /* Match parameters */
     std::regex output_regex("--output");
     std::regex device_regex("--device");
-    // device_vendor = std::string(".*");
-    // device_type   = std::string("*");
     /* Check if user has specified any options */
     bool match = true;
     for (int i = 1; i < argc; i++) {
@@ -84,7 +82,7 @@ struct benchmark_arguments {
       }
       // Check for the --output parameter
       if (std::regex_match(option, output_regex)) {
-        if (i + 1 >= argc) {
+        if ((i + 1) >= argc) {
           std::cerr << " Incorrect parameter " << std::endl;
           match = false;
           break;
@@ -108,7 +106,7 @@ struct benchmark_arguments {
 
       // Check for the --device parameter
       if (std::regex_match(option, device_regex)) {
-        if (i + 1 >= argc) {
+        if ((i + 1) >= argc) {
           std::cerr << " Incorrect parameter " << std::endl;
           match = false;
           break;
@@ -117,8 +115,7 @@ struct benchmark_arguments {
         std::transform(outputOption.begin(), outputOption.end(),
                        outputOption.begin(), ::tolower);
         // split the string into tokens on ':'
-        std::stringstream ss;
-        ss.str(outputOption);
+        std::stringstream ss(outputOption);
         std::string item;
         std::vector<std::string> tokens;
         while (std::getline(ss, item, ':')) {

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <iostream>
 #include <regex>
+#include "cli_device_selector.hpp"
 
 /**
  * output_type
@@ -43,6 +44,8 @@ enum class output_type {
 struct benchmark_arguments {
   std::string program_name;
   output_type requestedOutput;
+  std::string device_vendor;
+  std::string device_type;
   bool validProgramOptions;
 
   void usage() {
@@ -53,6 +56,10 @@ struct benchmark_arguments {
               << std::endl;
     std::cout << "         - CSV : Output to a CSV file " << std::endl;
     std::cout << "         - STDOUT: Output to stdout (default) " << std::endl;
+    std::cout << "  --device  DEVICE" << std::endl;
+    std::cout << "         Select a device (best effort) for running the benchmark."
+              << std::endl;
+    std::cout << "         e.g. intel:cpu, amd:gpu etc" << std::endl;
   }
 
   benchmark_arguments(int argc, char** argv)
@@ -61,6 +68,7 @@ struct benchmark_arguments {
         validProgramOptions(true) {
     /* Match parameters */
     std::regex output_regex("--output");
+    std::regex device_regex("--device");
     /* Check if user has specified any options */
     bool match = true;
     for (int i = 1; i < argc; i++) {
@@ -92,6 +100,36 @@ struct benchmark_arguments {
           break;
         }
         // Skip next parameter, since it was the name
+        i++;
+      }
+
+      // Check for the --device parameter
+      if (std::regex_match(option, device_regex)){
+        if (i + 1 >= argc) {
+          std::cerr << " Incorrect parameter " << std::endl;
+          match = false;
+          break;
+        }
+        std::string outputOption = argv[i + 1];
+        std::transform(outputOption.begin(), outputOption.end(), 
+                       outputOption.begin(), ::tolower);
+        // split the string into tokens on ':'
+        std::stringstream ss;
+        ss.str(outputOption);
+        std::string item;
+        std::vector<std::string> tokens;
+        while(std::getline(ss, item, ':')){
+          tokens.push_back(item);
+        }
+        if(tokens.size() != 2){
+          std::cerr << " Incorrect number of arguments to device selector " 
+            << std::endl;
+        }else{
+          device_vendor = tokens[0];
+          device_type = tokens[1];
+          matchedAnything = true;
+        }
+        // Skip next parameter, since it was the device
         i++;
       }
 
@@ -176,12 +214,13 @@ struct benchmark {
     if (!ba.validProgramOptions) {                                            \
       return 1;                                                               \
     }                                                                         \
+    cli_device_selector cds(ba.device_vendor, ba.device_type);                \
     const unsigned NUM_REPS = REPS;                                           \
     const unsigned STEP_SIZE = STEP_SIZE_PARAM;                               \
     const unsigned MAX_ELEMS = STEP_SIZE * (NUM_STEPS);                       \
     for (int nelems = STEP_SIZE; nelems < MAX_ELEMS; nelems *= STEP_SIZE) {   \
       const std::string short_name = NAME;                                    \
-      auto time = FUNCTION(NUM_REPS, nelems);                                 \
+      auto time = FUNCTION(NUM_REPS, nelems, cds);                            \
       benchmark<>::output_data(short_name, nelems, time, ba.requestedOutput); \
     }                                                                         \
   }

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -57,8 +57,9 @@ struct benchmark_arguments {
     std::cout << "         - CSV : Output to a CSV file " << std::endl;
     std::cout << "         - STDOUT: Output to stdout (default) " << std::endl;
     std::cout << "  --device  DEVICE" << std::endl;
-    std::cout << "         Select a device (best effort) for running the benchmark."
-              << std::endl;
+    std::cout
+        << "         Select a device (best effort) for running the benchmark."
+        << std::endl;
     std::cout << "         e.g. intel:cpu, amd:gpu etc" << std::endl;
   }
 
@@ -69,6 +70,8 @@ struct benchmark_arguments {
     /* Match parameters */
     std::regex output_regex("--output");
     std::regex device_regex("--device");
+    // device_vendor = std::string(".*");
+    // device_type   = std::string("*");
     /* Check if user has specified any options */
     bool match = true;
     for (int i = 1; i < argc; i++) {
@@ -104,27 +107,27 @@ struct benchmark_arguments {
       }
 
       // Check for the --device parameter
-      if (std::regex_match(option, device_regex)){
+      if (std::regex_match(option, device_regex)) {
         if (i + 1 >= argc) {
           std::cerr << " Incorrect parameter " << std::endl;
           match = false;
           break;
         }
         std::string outputOption = argv[i + 1];
-        std::transform(outputOption.begin(), outputOption.end(), 
+        std::transform(outputOption.begin(), outputOption.end(),
                        outputOption.begin(), ::tolower);
         // split the string into tokens on ':'
         std::stringstream ss;
         ss.str(outputOption);
         std::string item;
         std::vector<std::string> tokens;
-        while(std::getline(ss, item, ':')){
+        while (std::getline(ss, item, ':')) {
           tokens.push_back(item);
         }
-        if(tokens.size() != 2){
-          std::cerr << " Incorrect number of arguments to device selector " 
-            << std::endl;
-        }else{
+        if (tokens.size() != 2) {
+          std::cerr << " Incorrect number of arguments to device selector "
+                    << std::endl;
+        } else {
           device_vendor = tokens[0];
           device_type = tokens[1];
           matchedAnything = true;

--- a/benchmarks/cli_device_selector.hpp
+++ b/benchmarks/cli_device_selector.hpp
@@ -58,14 +58,9 @@ class cli_device_selector : public cl::sycl::device_selector {
   cli_device_selector(std::string vendor_name, std::string device_type)
       : cl::sycl::device_selector(),
         m_vendor_name(vendor_name),
-        m_device_type(device_type) {
-    std::cout << "Vendor name: " << m_vendor_name << std::endl;
-    std::cout << "Device type: " << m_device_type << std::endl;
-  }
+        m_device_type(device_type) {}
 
   int operator()(const cl::sycl::device &device) const {
-    std::cout << "Vendor name: " << m_vendor_name << std::endl;
-    std::cout << "Device type: " << m_device_type << std::endl;
     int score = 0;
 
     // Score the device type...

--- a/benchmarks/cli_device_selector.hpp
+++ b/benchmarks/cli_device_selector.hpp
@@ -68,21 +68,25 @@ class cli_device_selector : public cl::sycl::device_selector {
         device.get_info<cl::sycl::info::device::device_type>();
     cl::sycl::info::device_type rtype = match_device_type(m_device_type);
     if (rtype == dtype || rtype == cl::sycl::info::device_type::all) {
+      score += 2;
+    } else if (rtype == cl::sycl::info::device_type::defaults) {
       score += 1;
     } else {
-      score -= 1;
+      score -= 2;
     }
 
     // score the vendor name
     cl::sycl::platform plat = device.get_platform();
     std::string name = plat.template get_info<cl::sycl::info::platform::name>();
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-    if (name.find(m_vendor_name) != std::string::npos) {
+    if (name.find(m_vendor_name) != std::string::npos &&
+        !m_vendor_name.empty()) {
+      score += 2;
+    } else if (m_vendor_name == "*" || m_vendor_name.empty()) {
       score += 1;
     } else {
       score -= 2;
     }
-
     return score;
   }
 };

--- a/benchmarks/cli_device_selector.hpp
+++ b/benchmarks/cli_device_selector.hpp
@@ -1,0 +1,87 @@
+/* Copyright (c) 2015 The Khronos Group Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and/or associated documentation files (the
+   "Materials"), to deal in the Materials without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Materials, and to
+   permit persons to whom the Materials are furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Materials.
+
+   MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+   KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+   SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+    https://www.khronos.org/registry/
+
+  THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+*/
+
+#ifndef __INTEL_CPU_SELECTOR__
+#define __INTEL_CPU_SELECTOR__
+
+#include <SYCL/sycl.hpp>
+#include <string>
+#include <iostream>
+
+/** class cli_device_selector.
+* @brief Looks for an INTEL cpu among the available CPUs.
+* if it finds an INTEL CPU it will return an 1, otherwise it returns a -1.
+*/
+class cli_device_selector : public cl::sycl::device_selector {
+  std::string m_vendor_name;
+  std::string m_device_type;
+ public:
+  cli_device_selector(std::string vendor_name, std::string device_type) : 
+    cl::sycl::device_selector(), m_vendor_name(vendor_name), 
+    m_device_type(device_type) {
+      std::cout << "Vendor name: " << m_vendor_name << std::endl;
+      std::cout << "Device type: " << m_device_type << std::endl;
+    }
+
+  int operator()(const cl::sycl::device &device) const {
+    std::cout << "Vendor name: " << m_vendor_name << std::endl;
+    std::cout << "Device type: " << m_device_type << std::endl;
+    int score = 0;
+
+    // Score the device type...
+    cl::sycl::info::device_type type =
+      device.get_info<cl::sycl::info::device::device_type>();
+    std::string dtype;
+    if(type == cl::sycl::info::device_type::cpu){
+      dtype = "cpu";
+    }
+    if(type == cl::sycl::info::device_type::gpu){
+      dtype = "gpu";
+    }
+    if(dtype == m_device_type){
+      score += 1;
+    }else{
+      score -= 1;
+    }
+
+    // score the vendor name
+    cl::sycl::platform plat = device.get_platform();
+    std::string name = plat.template get_info<cl::sycl::info::platform::name>();
+    std::transform(name.begin(), name.end(), 
+                       name.begin(), ::tolower);
+    if (name.find(m_vendor_name) != std::string::npos) {
+      score += 1;
+    }else{
+      score -= 1;
+    }
+
+    return score;
+  }
+};
+
+#endif  // __INTEL_CPU_SELECTOR__

--- a/benchmarks/montecarloPI.cpp
+++ b/benchmarks/montecarloPI.cpp
@@ -45,7 +45,8 @@ int isInsideCircleFunctor(cl::sycl::float2 p) {
 }
 
 benchmark<>::time_units_t benchmark_montecarlo(const unsigned numReps,
-                                               const unsigned num_elems) {
+                                               const unsigned num_elems,
+                                               const cli_device_selector cds) {
   // Container for the random points
   std::vector<cl::sycl::float2> pointset;
   std::srand((unsigned int)std::time(0));
@@ -59,7 +60,7 @@ benchmark<>::time_units_t benchmark_montecarlo(const unsigned numReps,
   }
 
   auto myMontecarlo = [&]() {
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class MontecarloAlgorithm1> snp(q);
     count = std::experimental::parallel::transform_reduce(
         snp, pointset.begin(), pointset.end(),

--- a/benchmarks/nbody.cpp
+++ b/benchmarks/nbody.cpp
@@ -130,7 +130,8 @@ class Body {
  * @brief Body Function that executes the SYCL CG of NBODY
  */
 benchmark<>::time_units_t benchmark_nbody(const unsigned numReps,
-                                          const unsigned N) {
+                                          const unsigned N,
+                                          const cli_device_selector cds) {
   srand(time(NULL));
   std::vector<Body> bodies(N);
 
@@ -141,7 +142,7 @@ benchmark<>::time_units_t benchmark_nbody(const unsigned numReps,
   }
   auto mainLoop = [&]() {
     auto d_bodies = sycl::helpers::make_buffer(begin(bodies), end(bodies));
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     // Main loop
     auto vectorSize = d_bodies.get_count();
     auto f = [vectorSize, &d_bodies](cl::sycl::handler& h) mutable {

--- a/benchmarks/nbody.cpp
+++ b/benchmarks/nbody.cpp
@@ -51,7 +51,7 @@ class Body {
   cl::sycl::cl_float3 pos;  // position components
   cl::sycl::cl_float3 vel;  // velocity components
   cl::sycl::cl_float3 acc;  // force components
-  float mass;            // mass of the particle
+  float mass;               // mass of the particle
 
  public:
   /** generateBody
@@ -118,7 +118,7 @@ class Body {
    * @brief Function that prints the Body attributes to an ostream
    * @param os : The output stream
    */
-  void printToFile(std::ostream& os){
+  void printToFile(std::ostream& os) {
     os << pos.x() << " " << pos.y() << " " << pos.z() << " ";
     os << vel.x() << " " << vel.y() << " " << vel.z() << " ";
     os << acc.x() << " " << acc.y() << " " << acc.z() << " ";
@@ -167,9 +167,9 @@ benchmark<>::time_units_t benchmark_nbody(const unsigned numReps,
     sycl::sycl_execution_policy<class UpdateAlgorithm> snp2(q);
     std::experimental::parallel::for_each(snp2, begin(d_bodies), end(d_bodies),
                                           [=](Body& body) {
-      body.update();
-      return body;
-    });  // main loop
+                                            body.update();
+                                            return body;
+                                          });  // main loop
 
     q.wait_and_throw();
   };

--- a/benchmarks/std_foreach_saxpy.cpp
+++ b/benchmarks/std_foreach_saxpy.cpp
@@ -34,7 +34,8 @@
 #include "benchmark.h"
 
 benchmark<>::time_units_t benchmark_foreach(const unsigned numReps,
-                                            const unsigned num_elems) {
+                                            const unsigned num_elems,
+                                            const cli_device_selector cds) {
   std::vector<float> v1;
 
   for (int i = num_elems; i > 0; i--) {

--- a/benchmarks/std_sort.cpp
+++ b/benchmarks/std_sort.cpp
@@ -34,7 +34,8 @@
 #include "benchmark.h"
 
 benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
-                                         const unsigned num_elems) {
+                                         const unsigned num_elems,
+                                         const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {

--- a/benchmarks/std_transform_saxpy.cpp
+++ b/benchmarks/std_transform_saxpy.cpp
@@ -34,7 +34,8 @@
 #include "benchmark.h"
 
 benchmark<>::time_units_t benchmark_transform(const unsigned numReps,
-                                              const unsigned num_elems) {
+                                              const unsigned num_elems,
+                                              const cli_device_selector cds) {
   std::vector<float> v1;
   std::vector<float> v2;
   std::vector<float> res;

--- a/benchmarks/sycl_exclusive_scan.cpp
+++ b/benchmarks/sycl_exclusive_scan.cpp
@@ -41,9 +41,9 @@ using namespace sycl::helpers;
 /** benchmark_inclusive_scan
  * @brief Body Function that executes the SYCL CG of exclusive_scan
  */
-benchmark<>::time_units_t benchmark_exclusive_scan(const unsigned numReps,
-                                         const unsigned num_elems,
-                                         const cli_device_selector cds) {
+benchmark<>::time_units_t benchmark_exclusive_scan(
+    const unsigned numReps, const unsigned num_elems,
+    const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -53,14 +53,15 @@ benchmark<>::time_units_t benchmark_exclusive_scan(const unsigned numReps,
   auto exclusive_scan = [&]() {
     cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class ExclusiveScanAlgorithm1> snp(q);
-    std::experimental::parallel::exclusive_scan(snp, begin(v1), end(v1), 
-      begin(v1), 0, [=](int x, int y){ return x + y; });
+    std::experimental::parallel::exclusive_scan(
+        snp, begin(v1), end(v1), begin(v1), 0,
+        [=](int x, int y) { return x + y; });
   };
 
-  auto time = benchmark<>::duration(
-      numReps, exclusive_scan);
+  auto time = benchmark<>::duration(numReps, exclusive_scan);
 
   return time;
 }
 
-BENCHMARK_MAIN("BENCH_SYCL_EXCLUSIVE_SCAN", benchmark_exclusive_scan, 2u, 33554432u, 1);
+BENCHMARK_MAIN("BENCH_SYCL_EXCLUSIVE_SCAN", benchmark_exclusive_scan, 2u,
+               33554432u, 1);

--- a/benchmarks/sycl_exclusive_scan.cpp
+++ b/benchmarks/sycl_exclusive_scan.cpp
@@ -42,7 +42,8 @@ using namespace sycl::helpers;
  * @brief Body Function that executes the SYCL CG of exclusive_scan
  */
 benchmark<>::time_units_t benchmark_exclusive_scan(const unsigned numReps,
-                                         const unsigned num_elems) {
+                                         const unsigned num_elems,
+                                         const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -50,7 +51,7 @@ benchmark<>::time_units_t benchmark_exclusive_scan(const unsigned numReps,
   }
 
   auto exclusive_scan = [&]() {
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class ExclusiveScanAlgorithm1> snp(q);
     std::experimental::parallel::exclusive_scan(snp, begin(v1), end(v1), 
       begin(v1), 0, [=](int x, int y){ return x + y; });

--- a/benchmarks/sycl_foreach_saxpy.cpp
+++ b/benchmarks/sycl_foreach_saxpy.cpp
@@ -40,14 +40,15 @@
 using namespace sycl::helpers;
 
 benchmark<>::time_units_t benchmark_foreach(const unsigned numReps,
-                                            const unsigned num_elems) {
+                                            const unsigned num_elems,
+                                            const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
     v1.push_back(i);
   }
 
-  cl::sycl::queue q;
+  cl::sycl::queue q(cds);
   auto myforeach = [&]() {  
     sycl::sycl_execution_policy<class ForEachAlgorithm1> snp(q);
     std::experimental::parallel::for_each(

--- a/benchmarks/sycl_foreach_saxpy.cpp
+++ b/benchmarks/sycl_foreach_saxpy.cpp
@@ -49,7 +49,7 @@ benchmark<>::time_units_t benchmark_foreach(const unsigned numReps,
   }
 
   cl::sycl::queue q(cds);
-  auto myforeach = [&]() {  
+  auto myforeach = [&]() {
     sycl::sycl_execution_policy<class ForEachAlgorithm1> snp(q);
     std::experimental::parallel::for_each(
         snp, begin(v1), end(v1), [=](float val) { return val + val * val; });

--- a/benchmarks/sycl_inclusive_scan.cpp
+++ b/benchmarks/sycl_inclusive_scan.cpp
@@ -42,7 +42,8 @@ using namespace sycl::helpers;
  * @brief Body Function that executes the SYCL CG of inclusive_scan
  */
 benchmark<>::time_units_t benchmark_inclusive_scan(const unsigned numReps,
-                                         const unsigned num_elems) {
+                                         const unsigned num_elems,
+                                         const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -50,7 +51,7 @@ benchmark<>::time_units_t benchmark_inclusive_scan(const unsigned numReps,
   }
 
   auto inclusive_scan = [&]() {
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class InclusiveScanAlgorithm1> snp(q);
     std::experimental::parallel::inclusive_scan(snp, begin(v1), end(v1), 
       begin(v1), [=](int x, int y){ return x + y; });

--- a/benchmarks/sycl_inclusive_scan.cpp
+++ b/benchmarks/sycl_inclusive_scan.cpp
@@ -41,9 +41,9 @@ using namespace sycl::helpers;
 /** benchmark_inclusive_scan
  * @brief Body Function that executes the SYCL CG of inclusive_scan
  */
-benchmark<>::time_units_t benchmark_inclusive_scan(const unsigned numReps,
-                                         const unsigned num_elems,
-                                         const cli_device_selector cds) {
+benchmark<>::time_units_t benchmark_inclusive_scan(
+    const unsigned numReps, const unsigned num_elems,
+    const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -53,14 +53,15 @@ benchmark<>::time_units_t benchmark_inclusive_scan(const unsigned numReps,
   auto inclusive_scan = [&]() {
     cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class InclusiveScanAlgorithm1> snp(q);
-    std::experimental::parallel::inclusive_scan(snp, begin(v1), end(v1), 
-      begin(v1), [=](int x, int y){ return x + y; });
+    std::experimental::parallel::inclusive_scan(
+        snp, begin(v1), end(v1), begin(v1),
+        [=](int x, int y) { return x + y; });
   };
 
-  auto time = benchmark<>::duration(
-      numReps, inclusive_scan);
+  auto time = benchmark<>::duration(numReps, inclusive_scan);
 
   return time;
 }
 
-BENCHMARK_MAIN("BENCH_SYCL_INCLUSIVE_SCAN", benchmark_inclusive_scan, 2u, 33554432u, 1);
+BENCHMARK_MAIN("BENCH_SYCL_INCLUSIVE_SCAN", benchmark_inclusive_scan, 2u,
+               33554432u, 1);

--- a/benchmarks/sycl_reduce.cpp
+++ b/benchmarks/sycl_reduce.cpp
@@ -43,14 +43,15 @@ using namespace sycl::helpers;
  * @brief Body Function that executes the SYCL CG of Reduce
  */
 benchmark<>::time_units_t benchmark_reduce(const unsigned numReps,
-                                           const unsigned N) {
+                                           const unsigned N,
+                                           const cli_device_selector cds) {
   std::vector<int> v;
   for (int i = 0; i < N; i++) {
     int x = 10 * (((float)std::rand()) / RAND_MAX);
     v.push_back(x);
   }
 
-  cl::sycl::queue q;
+  cl::sycl::queue q(cds);
   auto device = q.get_device();
   auto local = device.get_info<cl::sycl::info::device::max_work_group_size>();
   sycl::sycl_execution_policy<class ReduceAlgorithmBench> snp(q);

--- a/benchmarks/sycl_sort.cpp
+++ b/benchmarks/sycl_sort.cpp
@@ -39,7 +39,8 @@
 using namespace sycl::helpers;
 
 benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
-                                         const unsigned num_elems) {
+                                         const unsigned num_elems,
+                                         const cli_device_selector cds) {
   std::vector<int> v1;
 
   for (int i = num_elems; i > 0; i--) {
@@ -47,7 +48,7 @@ benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
   }
 
   auto mysort = [&]() {
-    cl::sycl::queue q;
+    cl::sycl::queue q(cds);
     sycl::sycl_execution_policy<class SortAlgorithm1> snp(q);
     std::experimental::parallel::sort(snp, begin(v1), end(v1));
   };

--- a/benchmarks/sycl_sort.cpp
+++ b/benchmarks/sycl_sort.cpp
@@ -53,8 +53,7 @@ benchmark<>::time_units_t benchmark_sort(const unsigned numReps,
     std::experimental::parallel::sort(snp, begin(v1), end(v1));
   };
 
-  auto time = benchmark<>::duration(
-      numReps, mysort);
+  auto time = benchmark<>::duration(numReps, mysort);
 
   return time;
 }

--- a/benchmarks/sycl_transform_reduce_saxpy.cpp
+++ b/benchmarks/sycl_transform_reduce_saxpy.cpp
@@ -42,21 +42,20 @@ using namespace sycl::helpers;
 typedef struct elem {
   float a;
   float b;
-} elem; 
+} elem;
 
 #define PI 3.141
 
-benchmark<>::time_units_t benchmark_transform_reduce(const unsigned numReps,
-                                              const unsigned num_elems,
-                                              const cli_device_selector cds) {
+benchmark<>::time_units_t benchmark_transform_reduce(
+    const unsigned numReps, const unsigned num_elems,
+    const cli_device_selector cds) {
   std::vector<elem> v;
   auto expected = 0.0f;
 
-
   for (unsigned int i = num_elems; i > 0; i--) {
-    float a = 10.0f + static_cast<float>(10.0f*sin(i));
-    float b = 10.0f + static_cast<float>(10.0f*cos(i));
-    v.push_back({a,b});
+    float a = 10.0f + static_cast<float>(10.0f * sin(i));
+    float b = 10.0f + static_cast<float>(10.0f * cos(i));
+    v.push_back({a, b});
     expected += a * b * PI;
   }
 
@@ -66,9 +65,9 @@ benchmark<>::time_units_t benchmark_transform_reduce(const unsigned numReps,
   auto transformReduce = [&]() {
     float pi = PI;
     float res = std::experimental::parallel::transform_reduce(
-        snp, std::begin(v), std::end(v), 
-        [=](elem x){ return x.a * x.b * pi; }, 0, // map multiplication
-        [=](float a, float b){return a + b;}); // reduce addition
+        snp, std::begin(v), std::end(v), [=](elem x) { return x.a * x.b * pi; },
+        0,                                         // map multiplication
+        [=](float a, float b) { return a + b; });  // reduce addition
   };
 
   auto time = benchmark<>::duration(numReps, transformReduce);
@@ -76,4 +75,5 @@ benchmark<>::time_units_t benchmark_transform_reduce(const unsigned numReps,
   return time;
 }
 
-BENCHMARK_MAIN("BENCH_SYCL_TRANSFORM_REDUCE", benchmark_transform_reduce, 2u, 33554432u, 10);
+BENCHMARK_MAIN("BENCH_SYCL_TRANSFORM_REDUCE", benchmark_transform_reduce, 2u,
+               33554432u, 10);

--- a/benchmarks/sycl_transform_reduce_saxpy.cpp
+++ b/benchmarks/sycl_transform_reduce_saxpy.cpp
@@ -47,7 +47,8 @@ typedef struct elem {
 #define PI 3.141
 
 benchmark<>::time_units_t benchmark_transform_reduce(const unsigned numReps,
-                                              const unsigned num_elems) {
+                                              const unsigned num_elems,
+                                              const cli_device_selector cds) {
   std::vector<elem> v;
   auto expected = 0.0f;
 
@@ -59,7 +60,7 @@ benchmark<>::time_units_t benchmark_transform_reduce(const unsigned numReps,
     expected += a * b * PI;
   }
 
-  cl::sycl::queue q;
+  cl::sycl::queue q(cds);
   sycl::sycl_execution_policy<class TransformReduceAlgorithm1> snp(q);
 
   auto transformReduce = [&]() {

--- a/benchmarks/sycl_transform_saxpy.cpp
+++ b/benchmarks/sycl_transform_saxpy.cpp
@@ -40,7 +40,8 @@
 using namespace sycl::helpers;
 
 benchmark<>::time_units_t benchmark_transform(const unsigned numReps,
-                                              const unsigned num_elems) {
+                                              const unsigned num_elems,
+                                              const cli_device_selector cds) {
   std::vector<int> v1;
   std::vector<int> v2;
   std::vector<int> res;
@@ -50,7 +51,7 @@ benchmark<>::time_units_t benchmark_transform(const unsigned numReps,
     v2.push_back(i);
     res.push_back(i);
   }
-  cl::sycl::queue q;
+  cl::sycl::queue q(cds);
   sycl::sycl_execution_policy<class TransformAlgorithm1> snp(q);
 
   auto mytransform = [&]() {


### PR DESCRIPTION
At present, there is no offical way in the SYCL spec of selecting a specific OpenCL device for an existing, compiled application. This PR provides a SYCL device selector for matching devices of a requested vendor and type, as well as a command line flag, `--device` for the benchmark applications for triggering the selector.