### PR TITLE
removal of unused variables/typedef

### DIFF
--- a/include/sycl/algorithm/count_if.hpp
+++ b/include/sycl/algorithm/count_if.hpp
@@ -63,7 +63,6 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
   auto local =
       std::min(device.get_info<cl::sycl::info::device::max_work_group_size>(),
                vectorSize);
-  typedef typename std::iterator_traits<InputIterator>::value_type type_;
   auto bufI = sycl::helpers::make_const_buffer(first, last);
   cl::sycl::buffer<int, 1> bufR((cl::sycl::range<1>(vectorSize)));
   size_t length = exec.calculateGlobalSize(vectorSize, local);
@@ -83,8 +82,6 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           r, [aI, aR, scratch, local, length, passes, unary_op, binary_op](
                  cl::sycl::nd_item<1> id) {
-            int globalid = id.get_global(0);
-            int localid = id.get_local(0);
             auto r = ReductionStrategy<int>(local, length, id, scratch);
             if (passes == 0) {
               r.workitem_get_from(unary_op, aI);

--- a/include/sycl/algorithm/exclusive_scan.hpp
+++ b/include/sycl/algorithm/exclusive_scan.hpp
@@ -111,8 +111,8 @@ OutputIterator exclusive_scan(ExecutionPolicy &sep, InputIterator b,
       h.parallel_for<
           cl::sycl::helpers::NameGen<1, typename ExecutionPolicy::kernelName> >(
           r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<3> id) {
-            int td = 1 << (i - 1);
-            int m_id = id.get_global(0);
+            size_t td = 1 << (i - 1);
+            size_t m_id = id.get_global(0);
             if (m_id < vectorSize && m_id >= td) {
               aO[m_id] = bop(aI[m_id - td], aI[m_id]);
             } else {

--- a/include/sycl/algorithm/find.hpp
+++ b/include/sycl/algorithm/find.hpp
@@ -136,9 +136,6 @@ InputIt find_impl(ExecutionPolicy &sep, InputIt b, InputIt e,
       h.parallel_for<
           cl::sycl::helpers::NameGen<1, typename ExecutionPolicy::kernelName> >(
           r, [aI, scratch, localRange, length, bop](cl::sycl::nd_item<3> id) {
-            int globalid = id.get_global(0);
-            int localid = id.get_local(0);
-
             auto r = ReductionStrategy<search_result>(localRange, length, id,
                                                       scratch);
             r.workitem_get_from(aI);

--- a/include/sycl/algorithm/for_each.hpp
+++ b/include/sycl/algorithm/for_each.hpp
@@ -50,7 +50,6 @@ void for_each(ExecutionPolicy &sep, Iterator b, Iterator e, UnaryFunction op) {
     auto device = q.get_device();
     size_t localRange =
         device.get_info<cl::sycl::info::device::max_work_group_size>();
-    typedef typename std::iterator_traits<Iterator>::value_type type_;
     auto bufI = sycl::helpers::make_buffer(b, e);
     auto vectorSize = bufI.get_count();
     size_t globalRange = sep.calculateGlobalSize(vectorSize, localRange);

--- a/include/sycl/algorithm/inclusive_scan.hpp
+++ b/include/sycl/algorithm/inclusive_scan.hpp
@@ -89,8 +89,8 @@ OutputIterator inclusive_scan(ExecutionPolicy &sep, InputIterator b,
           outBuf->template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<3> id) {
-            int td = 1 << (i - 1);
-            int m_id = id.get_global(0);
+            size_t td = 1 << (i - 1);
+            size_t m_id = id.get_global(0);
 
             if (m_id < vectorSize && m_id >= td) {
               aO[m_id] = bop(aI[m_id - td], aI[m_id]);

--- a/include/sycl/algorithm/inner_product.hpp
+++ b/include/sycl/algorithm/inner_product.hpp
@@ -125,8 +125,6 @@ T inner_product(ExecutionPolicy &exec, InputIt1 first1, InputIt1 last1,
         h.parallel_for<typename ExecutionPolicy::kernelName>(
             r, [a1, a2, aR, scratch, length, local, passes, op1, op2](
                    cl::sycl::nd_item<3> id) {
-              int globalid = id.get_global(0);
-              int localid = id.get_local(0);
               auto r = ReductionStrategy<T>(local, length, id, scratch);
               if (passes == 0) {
                 r.workitem_get_from(op2, a1, a2);

--- a/include/sycl/algorithm/reduce.hpp
+++ b/include/sycl/algorithm/reduce.hpp
@@ -80,9 +80,6 @@ typename std::iterator_traits<Iterator>::value_type reduce(
 
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           r, [aI, scratch, local, length, bop](cl::sycl::nd_item<3> id) {
-            int globalid = id.get_global(0);
-            int localid = id.get_local(0);
-
             auto r = ReductionStrategy<T>(local, length, id, scratch);
             r.workitem_get_from(aI);
             r.combine_threads(bop);

--- a/include/sycl/algorithm/sort.hpp
+++ b/include/sycl/algorithm/sort.hpp
@@ -84,8 +84,8 @@ class sort_kernel_sequential {
 
   // Simple sequential sort
   void operator()() {
-    for (int i = 0; i < vS_; i++) {
-      for (int j = 1; j < vS_; j++) {
+    for (size_t i = 0; i < vS_; i++) {
+      for (size_t j = 1; j < vS_; j++) {
         if (a_[j - 1] > a_[j]) {
           sort_swap<T>(a_[j - 1], a_[j]);
         }

--- a/include/sycl/algorithm/transform_reduce.hpp
+++ b/include/sycl/algorithm/transform_reduce.hpp
@@ -63,7 +63,6 @@ T transform_reduce(ExecutionPolicy& exec, InputIterator first,
   auto local =
       std::min(device.get_info<cl::sycl::info::device::max_work_group_size>(),
                vectorSize);
-  typedef typename std::iterator_traits<InputIterator>::value_type type_;
   auto bufI = sycl::helpers::make_const_buffer(first, last);
   size_t length = vectorSize;
   size_t global = exec.calculateGlobalSize(vectorSize, local);
@@ -83,8 +82,6 @@ T transform_reduce(ExecutionPolicy& exec, InputIterator first,
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           r, [aI, aR, scratch, passes, local, length, unary_op, binary_op](
                  cl::sycl::nd_item<3> id) {
-            int globalid = id.get_global(0);
-            int localid = id.get_local(0);
             auto r = ReductionStrategy<T>(local, length, id, scratch);
             if (passes == 0) {
               r.workitem_get_from(unary_op, aI);


### PR DESCRIPTION
include/sycl/algorithm/
	- sort.hpp
		replace int by size_t in lines 87, 88
	- exclusive_scan.hpp
		replace int by size_t in lines 114, 115
	- inner_product.hpp
		remove lines 128, 129 : unused variables (localid, globalid)
	- tranform_reduce.hpp
		remove line 66 : unused type
		remove lines 85, 86 : unused variables (localid, globalid)
	- inclusive_scan.hpp
		replace int by size_t in lines 92, 93
	- count_if.hpp
		remove line 66 : unused type
		remove lines 86, 87 : unused variables (localid, globalid)
	- for_each.hpp
		remove line 53 : unused type