### PR TITLE
Replace all 3D ndrange with 1D range

### DIFF
--- a/include/sycl/algorithm/algorithm_composite_patterns.hpp
+++ b/include/sycl/algorithm/algorithm_composite_patterns.hpp
@@ -51,11 +51,11 @@ class ReductionStrategy {
   int globalid_;
   int local_;
   int length_;
-  cl::sycl::nd_item<3> id_;
+  cl::sycl::nd_item<1> id_;
   local_rw_acc<T> scratch_;
 
  public:
-  ReductionStrategy(int loc, int len, cl::sycl::nd_item<3> i,
+  ReductionStrategy(int loc, int len, cl::sycl::nd_item<1> i,
                     const local_rw_acc<T>& localmem)
       : localid_(i.get_local(0)),
         globalid_(i.get_global(0)),

--- a/include/sycl/algorithm/exclusive_scan.hpp
+++ b/include/sycl/algorithm/exclusive_scan.hpp
@@ -77,15 +77,15 @@ OutputIterator exclusive_scan(ExecutionPolicy &sep, InputIterator b,
   // (with initial set at element 0) followed by an inclusive scan
   auto shr = [vectorSize, localRange, globalRange, inBuf, outBuf, init](
       cl::sycl::handler &h) {
-    cl::sycl::nd_range<3> r{
-        cl::sycl::range<3>{std::max(globalRange, localRange), 1, 1},
-        cl::sycl::range<3>{localRange, 1, 1}};
+    cl::sycl::nd_range<1> r{
+        cl::sycl::range<1>{std::max(globalRange, localRange)},
+        cl::sycl::range<1>{localRange}};
     auto aI = inBuf->template get_access<cl::sycl::access::mode::read>(h);
     auto aO = outBuf->template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<
         cl::sycl::helpers::NameGen<0, typename ExecutionPolicy::kernelName> >(
-        r, [aI, aO, init, vectorSize](cl::sycl::nd_item<3> id) {
-          int m_id = id.get_global(0);
+        r, [aI, aO, init, vectorSize](cl::sycl::nd_item<1> id) {
+          size_t m_id = id.get_global(0);
           if (m_id > 0) {
             aO[m_id] = aI[m_id - 1];
           } else {
@@ -101,16 +101,16 @@ OutputIterator exclusive_scan(ExecutionPolicy &sep, InputIterator b,
   do {
     auto f = [vectorSize, i, localRange, globalRange, inBuf, outBuf, bop](
         cl::sycl::handler &h) {
-      cl::sycl::nd_range<3> r{
-          cl::sycl::range<3>{std::max(globalRange, localRange), 1, 1},
-          cl::sycl::range<3>{localRange, 1, 1}};
+      cl::sycl::nd_range<1> r{
+          cl::sycl::range<1>{std::max(globalRange, localRange)},
+          cl::sycl::range<1>{localRange}};
       auto aI =
           inBuf->template get_access<cl::sycl::access::mode::read_write>(h);
       auto aO =
           outBuf->template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<
           cl::sycl::helpers::NameGen<1, typename ExecutionPolicy::kernelName> >(
-          r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<3> id) {
+          r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<1> id) {
             size_t td = 1 << (i - 1);
             size_t m_id = id.get_global(0);
             if (m_id < vectorSize && m_id >= td) {

--- a/include/sycl/algorithm/fill.hpp
+++ b/include/sycl/algorithm/fill.hpp
@@ -57,12 +57,12 @@ void fill(ExecutionPolicy &sep, ForwardIt b, ForwardIt e, const T &value) {
     size_t globalRange = sep.calculateGlobalSize(vectorSize, localRange);
     auto f = [vectorSize, localRange, globalRange, &bufI, val](
         cl::sycl::handler &h) mutable {
-      cl::sycl::nd_range<3> r{
-          cl::sycl::range<3>{std::max(globalRange, localRange), 1, 1},
-          cl::sycl::range<3>{localRange, 1, 1}};
+      cl::sycl::nd_range<1> r{
+          cl::sycl::range<1>{std::max(globalRange, localRange)},
+          cl::sycl::range<1>{localRange}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, val, vectorSize](cl::sycl::nd_item<3> id) {
+          r, [aI, val, vectorSize](cl::sycl::nd_item<1> id) {
             if (id.get_global(0) < vectorSize) {
               aI[id.get_global(0)] = val;
             }

--- a/include/sycl/algorithm/for_each.hpp
+++ b/include/sycl/algorithm/for_each.hpp
@@ -55,12 +55,12 @@ void for_each(ExecutionPolicy &sep, Iterator b, Iterator e, UnaryFunction op) {
     size_t globalRange = sep.calculateGlobalSize(vectorSize, localRange);
     auto f = [vectorSize, localRange, globalRange, &bufI, op](
         cl::sycl::handler &h) mutable {
-      cl::sycl::nd_range<3> r{
-          cl::sycl::range<3>{std::max(globalRange, localRange), 1, 1},
-          cl::sycl::range<3>{localRange, 1, 1}};
+      cl::sycl::nd_range<1> r{
+          cl::sycl::range<1>{std::max(globalRange, localRange)},
+          cl::sycl::range<1>{localRange}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, op, vectorSize](cl::sycl::nd_item<3> id) {
+          r, [aI, op, vectorSize](cl::sycl::nd_item<1> id) {
             if (id.get_global(0) < vectorSize) {
               op(aI[id.get_global(0)]);
             }

--- a/include/sycl/algorithm/for_each_n.hpp
+++ b/include/sycl/algorithm/for_each_n.hpp
@@ -61,11 +61,11 @@ InputIterator for_each_n(ExecutionPolicy &exec, InputIterator first, Size n,
     size_t global = exec.calculateGlobalSize(vectorSize, local);
     auto cg = [vectorSize, local, global, &bufI, f](
         cl::sycl::handler &h) mutable {
-      cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                              cl::sycl::range<3>{local, 1, 1}};
+      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [vectorSize, aI, f](cl::sycl::nd_item<3> id) {
+          r, [vectorSize, aI, f](cl::sycl::nd_item<1> id) {
             if (id.get_global(0) < vectorSize) {
               f(aI[id.get_global(0)]);
             }

--- a/include/sycl/algorithm/inclusive_scan.hpp
+++ b/include/sycl/algorithm/inclusive_scan.hpp
@@ -80,15 +80,15 @@ OutputIterator inclusive_scan(ExecutionPolicy &sep, InputIterator b,
   do {
     auto f = [vectorSize, i, localRange, globalRange, inBuf, outBuf, bop](
         cl::sycl::handler &h) {
-      cl::sycl::nd_range<3> r{
-          cl::sycl::range<3>{std::max(globalRange, localRange), 1, 1},
-          cl::sycl::range<3>{localRange, 1, 1}};
+      cl::sycl::nd_range<1> r{
+          cl::sycl::range<1>{std::max(globalRange, localRange)},
+          cl::sycl::range<1>{localRange}};
       auto aI =
           inBuf->template get_access<cl::sycl::access::mode::read_write>(h);
       auto aO =
           outBuf->template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<3> id) {
+          r, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<1> id) {
             size_t td = 1 << (i - 1);
             size_t m_id = id.get_global(0);
 

--- a/include/sycl/algorithm/inner_product.hpp
+++ b/include/sycl/algorithm/inner_product.hpp
@@ -118,13 +118,15 @@ T inner_product(ExecutionPolicy &exec, InputIt1 first1, InputIt1 last1,
         cl::sycl::accessor<T, 1, cl::sycl::access::mode::read_write,
                            cl::sycl::access::target::local>
             scratch(cl::sycl::range<1>(local), h);
-        cl::sycl::nd_range<3> r{
-            cl::sycl::range<3>{std::max(global, local), 1, 1},
-            cl::sycl::range<3>{local, 1, 1}};
+        cl::sycl::nd_range<1> r{
+            cl::sycl::range<1>{std::max(global, local)},
+            cl::sycl::range<1>{local}};
 
         h.parallel_for<typename ExecutionPolicy::kernelName>(
             r, [a1, a2, aR, scratch, length, local, passes, op1, op2](
-                   cl::sycl::nd_item<3> id) {
+                   cl::sycl::nd_item<1> id) {
+              size_t globalid = id.get_global(0);
+              size_t localid = id.get_local(0);
               auto r = ReductionStrategy<T>(local, length, id, scratch);
               if (passes == 0) {
                 r.workitem_get_from(op2, a1, a2);

--- a/include/sycl/algorithm/reduce.hpp
+++ b/include/sycl/algorithm/reduce.hpp
@@ -71,15 +71,15 @@ typename std::iterator_traits<Iterator>::value_type reduce(
 
   do {
     auto f = [length, local, global, &bufI, bop](cl::sycl::handler &h) mutable {
-      cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                              cl::sycl::range<3>{local, 1, 1}};
+      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       cl::sycl::accessor<type_, 1, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::local>
           scratch(cl::sycl::range<1>(local), h);
 
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, scratch, local, length, bop](cl::sycl::nd_item<3> id) {
+          r, [aI, scratch, local, length, bop](cl::sycl::nd_item<1> id) {
             auto r = ReductionStrategy<T>(local, length, id, scratch);
             r.workitem_get_from(aI);
             r.combine_threads(bop);

--- a/include/sycl/algorithm/transform.hpp
+++ b/include/sycl/algorithm/transform.hpp
@@ -63,12 +63,12 @@ OutputIterator transform(ExecutionPolicy &sep, Iterator b, Iterator e,
     size_t global = sep.calculateGlobalSize(vectorSize, local);
     auto f = [vectorSize, local, global, &bufI, &bufO, op](
         cl::sycl::handler &h) {
-      cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                              cl::sycl::range<3>{local, 1, 1}};
+      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read>(h);
       auto aO = bufO.template get_access<cl::sycl::access::mode::write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, aO, op, vectorSize](cl::sycl::nd_item<3> id) {
+          r, [aI, aO, op, vectorSize](cl::sycl::nd_item<1> id) {
             if ((id.get_global(0) < vectorSize)) {
               aO[id.get_global(0)] = op(aI[id.get_global(0)]);
             }
@@ -104,13 +104,13 @@ OutputIterator transform(ExecutionPolicy &sep, InputIterator first1,
   size_t global = sep.calculateGlobalSize(n, local);
   auto f = [n, local, global, &buf1, &buf2, &res, op](
       cl::sycl::handler &h) mutable {
-    cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                            cl::sycl::range<3>{local, 1, 1}};
+    cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                            cl::sycl::range<1>{local}};
     auto a1 = buf1.template get_access<cl::sycl::access::mode::read>(h);
     auto a2 = buf2.template get_access<cl::sycl::access::mode::read>(h);
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
-        r, [a1, a2, aO, op, n](cl::sycl::nd_item<3> id) {
+        r, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
           if (id.get_global(0) < n) {
             aO[id.get_global(0)] =
                 op(a1[id.get_global(0)], a2[id.get_global(0)]);
@@ -147,13 +147,13 @@ OutputIterator transform(ExecutionPolicy &sep, cl::sycl::queue &q,
   size_t global = sep.calculateGlobalSize(n, local);
   auto f = [n, local, global, &buf1, &buf2, &res, op](
       cl::sycl::handler &h) mutable {
-    cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                            cl::sycl::range<3>{local, 1, 1}};
+    cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                            cl::sycl::range<1>{local}};
     auto a1 = buf1.template get_access<cl::sycl::access::mode::read>(h);
     auto a2 = buf2.template get_access<cl::sycl::access::mode::read>(h);
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
-        r, [a1, a2, aO, op, n](cl::sycl::nd_item<3> id) {
+        r, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
           if (id.get_global(0) < n) {
             aO[id.get_global(0)] =
                 op(a1[id.get_global(0)], a2[id.get_global(0)]);
@@ -183,13 +183,13 @@ void transform(ExecutionPolicy &sep, cl::sycl::queue &q, Buffer &buf1,
   size_t global = sep.calculateGlobalSize(n, local);
   auto f = [n, local, global, &buf1, &buf2, &res, op](
       cl::sycl::handler &h) mutable {
-    cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                            cl::sycl::range<3>{local, 1, 1}};
+    cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                            cl::sycl::range<1>{local}};
     auto a1 = buf1.template get_access<cl::sycl::access::mode::read>(h);
     auto a2 = buf2.template get_access<cl::sycl::access::mode::read>(h);
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<class TransformAlgorithm>(
-        r, [a1, a2, aO, op, n](cl::sycl::nd_item<3> id) {
+        r, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
           if (id.get_global(0) < n) {
             aO[id.get_global(0)] =
                 op(a1[id.get_global(0)], a2[id.get_global(0)]);

--- a/include/sycl/algorithm/transform_reduce.hpp
+++ b/include/sycl/algorithm/transform_reduce.hpp
@@ -71,8 +71,8 @@ T transform_reduce(ExecutionPolicy& exec, InputIterator first,
   do {
     auto f = [passes, length, local, global, &bufI, &bufR, unary_op, binary_op](
         cl::sycl::handler& h) mutable {
-      cl::sycl::nd_range<3> r{cl::sycl::range<3>{std::max(global, local), 1, 1},
-                              cl::sycl::range<3>{local, 1, 1}};
+      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
+                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read>(h);
       auto aR = bufR.template get_access<cl::sycl::access::mode::read_write>(h);
       cl::sycl::accessor<T, 1, cl::sycl::access::mode::read_write,
@@ -81,7 +81,7 @@ T transform_reduce(ExecutionPolicy& exec, InputIterator first,
 
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           r, [aI, aR, scratch, passes, local, length, unary_op, binary_op](
-                 cl::sycl::nd_item<3> id) {
+                 cl::sycl::nd_item<1> id) {
             auto r = ReductionStrategy<T>(local, length, id, scratch);
             if (passes == 0) {
               r.workitem_get_from(unary_op, aI);


### PR DESCRIPTION
Since all Parallel STL algorithms are currently working only with 1D
accessors, there is no need to use the 3D nd_range constructs.

This patch replaces all 3D nd_range and nd_items by the 1D counterparts. 

This should also fix #6 