### PR TITLE
upgrade: build.sh and CMakeLists.txt to be triSYCL compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,38 +10,38 @@ message(STATUS " Path to CMAKE source directory: ${CMAKE_SOURCE_DIR} ")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules/)
 
 if (USE_COMPUTECPP)
-	message(STATUS " Using ComputeCpp CMake")
+  message(STATUS " Using ComputeCpp CMake")
 
-	message(STATUS " Path to ComputeCpp implementation: ${COMPUTECPP_PACKAGE_ROOT_DIR} ")
+  message(STATUS " Path to ComputeCpp implementation: ${COMPUTECPP_PACKAGE_ROOT_DIR} ")
 
-	include(FindOpenCL)
-	include(FindComputeCpp)
+  include(FindOpenCL)
+  include(FindComputeCpp)
 
-	include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
+  include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
 
 else()
-	message(STATUS " Using triSYCL CMake")
-	set(CMAKE_CXX_STANDARD 14)
-	set(CXX_STANDARD_REQUIRED ON)
+  message(STATUS " Using triSYCL CMake")
+  set(CMAKE_CXX_STANDARD 14)
+  set(CXX_STANDARD_REQUIRED ON)
 
-	if(TRISYCL_INCLUDE_DIR)
-		message(STATUS "Path to triSYCL include directory: " ${TRISYCL_INCLUDE_DIR})
-		include_directories(${TRISYCL_INCLUDE_DIR})
-	endif()
-	if(BOOST_COMPUTE_INCLUDE_DIR)
-		message(STATUS "Path to Boost compute include directory: " ${BOOST_COMPUTE_INCLUDE_DIR})
-		include_directories(${BOOST_COMPUTE_INCLUDE_DIR})
-	endif()
+  if(TRISYCL_INCLUDE_DIR)
+    message(STATUS "Path to triSYCL include directory: " ${TRISYCL_INCLUDE_DIR})
+    include_directories(${TRISYCL_INCLUDE_DIR})
+  endif()
+  if(BOOST_COMPUTE_INCLUDE_DIR)
+    message(STATUS "Path to Boost compute include directory: " ${BOOST_COMPUTE_INCLUDE_DIR})
+    include_directories(${BOOST_COMPUTE_INCLUDE_DIR})
+  endif()
 
-	include(FindOpenCL)
+  include(FindOpenCL)
 
-	function(add_sycl_to_target targetName sourceFile binaryDir)
-	endfunction(add_sycl_to_target)
+  function(add_sycl_to_target targetName sourceFile binaryDir)
+  endfunction(add_sycl_to_target)
 
 endif()
 
 
-# PSTL specific 
+# PSTL specific
 include_directories("include")
 
 add_subdirectory (src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,42 @@ project (SyclSTL)
 enable_testing()
 
 option(PARALLEL_STL_BENCHMARKS "Build the internal benchmarks" OFF)
+option(USE_COMPUTECPP "Use ComputeCPP" ON)
 
-message(STATUS " Path to SYCL implementation: ${COMPUTECPP_PACKAGE_ROOT_DIR} ")
 message(STATUS " Path to CMAKE source directory: ${CMAKE_SOURCE_DIR} ")
-
-
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules/)
 
-include(FindOpenCL)
-include(FindComputeCpp)
+if (USE_COMPUTECPP)
+	message(STATUS " Using ComputeCpp CMake")
 
-include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
+	message(STATUS " Path to ComputeCpp implementation: ${COMPUTECPP_PACKAGE_ROOT_DIR} ")
+
+	include(FindOpenCL)
+	include(FindComputeCpp)
+
+	include_directories("${COMPUTECPP_INCLUDE_DIRECTORY}")
+
+else()
+	message(STATUS " Using triSYCL CMake")
+	set(CMAKE_CXX_STANDARD 14)
+	set(CXX_STANDARD_REQUIRED ON)
+
+	if(TRISYCL_INCLUDE_DIR)
+		message(STATUS "Path to triSYCL include directory: " ${TRISYCL_INCLUDE_DIR})
+		include_directories(${TRISYCL_INCLUDE_DIR})
+	endif()
+	if(BOOST_COMPUTE_INCLUDE_DIR)
+		message(STATUS "Path to Boost compute include directory: " ${BOOST_COMPUTE_INCLUDE_DIR})
+		include_directories(${BOOST_COMPUTE_INCLUDE_DIR})
+	endif()
+
+	include(FindOpenCL)
+
+	function(add_sycl_to_target targetName sourceFile binaryDir)
+	endfunction(add_sycl_to_target)
+
+endif()
+
 
 # PSTL specific 
 include_directories("include")

--- a/README.md
+++ b/README.md
@@ -104,8 +104,27 @@ CMake rules for intermediate file generation.
 Refer to your SYCL implementation documentation for 
 implementation-specific building options.
 
-Note, the included build.sh is for internal testing purposes only, and should 
-not be relied on for configuring/building SyclParallelSTL.
+To quickly build the project you can use the script build.sh:
+
+If you want to compile it with ComputeCpp:
+
+    ./build.sh "path/to/ComputeCpp" (this path can be relative)
+    
+for example (on Ubuntu 16.04):
+
+    ./build.sh ~/ComputeCpp
+    
+If you want to compile it with triSYCL:
+
+    ./build.sh --trisycl [-DTRISYCL_INCLUDE_DIR=path/to/triSYCL/include] [-DBOOST_COMPUTE_INCLUDE_DIR=path/to/boost/compute/include]
+    
+for example (on Ubuntu 16.04):
+
+    ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=~/triSYCL/include -DBOOST_COMPUTE_INCLUDE_DIR=~/compute/include
+
+or (if Boost compute is in your library's default path) 
+
+    ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=~/triSYCL/include
 
 Building the documentation
 ----------------------------

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,37 @@
 #!/bin/bash
-# the path to the ComputeCPP package root directory, e.g. /home/user/ComputeCpp-CE-0.1-Linux/
-PACKAGE_ROOT=$1
 
-#compute the number of cores
+# How to use build.sh to compile SyclParallelSTL with ComputeCpp ?
+# ./build.sh "path/to/ComputeCpp" (this path can be relative)
+#
+# for example:
+#	./build.sh /home/user/ComputeCpp
+#
+# How to use build.sh to compile SyclParallelSTL with triSYCL ?
+# ./build.sh --trisycl [-DTRISYCL_INCLUDE_DIR=path/to/triSYCL/include] [-DBOOST_COMPUTE_INCLUDE_DIR=path/to/boost/compute/include]
+#
+# for example (Ubuntu 16.04):
+#	./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=~/triSYCL/include -DBOOST_COMPUTE_INCLUDE_DIR=~/compute/include
+#
+#
+
+
+# Useless to go on when an error occurs
+set -o errexit
+
+if [ $1 == "--trisycl" ]
+then
+	shift
+	echo "build.sh enter mode: triSYCL"
+	CMAKE_ARGS="$CMAKE_ARGS -DUSE_COMPUTECPP=OFF $@"
+else
+	echo "build.sh enter mode: ComputeCpp"
+	CMAKE_ARGS="$CMAKE_ARGS -DCOMPUTECPP_PACKAGE_ROOT_DIR=$(readlink -f $1)"
+	shift
+fi
 NPROC=$(nproc)
 
 function install_gmock  {(
-  REPO="git@github.com:google/googletest.git"
-  #REPO="https://github.com/google/googletest.git"
+  REPO="https://github.com/google/googletest.git"
   mkdir -p external
   cd external
   if [ -d googletest ]
@@ -23,8 +47,8 @@ function install_gmock  {(
 )}
 
 function configure  {
-  mkdir -p build && pushd build 
-  cmake .. -DCOMPUTECPP_PACKAGE_ROOT_DIR=$PACKAGE_ROOT  -DPARALLEL_STL_BENCHMARKS=ON
+  mkdir -p build && pushd build
+  cmake .. $CMAKE_ARGS -DPARALLEL_STL_BENCHMARKS=ON
   popd
 }
 

--- a/build.sh
+++ b/build.sh
@@ -4,13 +4,13 @@
 # ./build.sh "path/to/ComputeCpp" (this path can be relative)
 #
 # for example:
-#	./build.sh /home/user/ComputeCpp
+#  ./build.sh /home/user/ComputeCpp
 #
 # How to use build.sh to compile SyclParallelSTL with triSYCL ?
 # ./build.sh --trisycl [-DTRISYCL_INCLUDE_DIR=path/to/triSYCL/include] [-DBOOST_COMPUTE_INCLUDE_DIR=path/to/boost/compute/include]
 #
 # for example (Ubuntu 16.04):
-#	./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=~/triSYCL/include -DBOOST_COMPUTE_INCLUDE_DIR=~/compute/include
+#  ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=~/triSYCL/include -DBOOST_COMPUTE_INCLUDE_DIR=~/compute/include
 #
 #
 
@@ -20,13 +20,13 @@ set -o errexit
 
 if [ $1 == "--trisycl" ]
 then
-	shift
-	echo "build.sh enter mode: triSYCL"
-	CMAKE_ARGS="$CMAKE_ARGS -DUSE_COMPUTECPP=OFF $@"
+  shift
+  echo "build.sh enter mode: triSYCL"
+  CMAKE_ARGS="$CMAKE_ARGS -DUSE_COMPUTECPP=OFF $@"
 else
-	echo "build.sh enter mode: ComputeCpp"
-	CMAKE_ARGS="$CMAKE_ARGS -DCOMPUTECPP_PACKAGE_ROOT_DIR=$(readlink -f $1)"
-	shift
+  echo "build.sh enter mode: ComputeCpp"
+  CMAKE_ARGS="$CMAKE_ARGS -DCOMPUTECPP_PACKAGE_ROOT_DIR=$(readlink -f $1)"
+  shift
 fi
 NPROC=$(nproc)
 
@@ -36,11 +36,11 @@ function install_gmock  {(
   cd external
   if [ -d googletest ]
   then
-	  cd googletest
-	  git pull
+    cd googletest
+    git pull
   else
-	  git clone $REPO
-	  cd googletest
+    git clone $REPO
+    cd googletest
   fi
   cd googlemock/make
   make -j$NPROC
@@ -60,7 +60,7 @@ function mak  {
 function tst {
   pushd build/tests
   ctest -j$NPROC
-  popd 
+  popd
 }
 
 function main {


### PR DESCRIPTION
build.sh is retro-compatible (i.e. ./build.sh /path/to/compute still works)
use ./build.sh --trisycl "path/to/trisycl" "path/to/compute" to use the trisycl mode
compute refers to boost/compute

CMakeLists.txt is also retro-compatible:
  set variables USE_COMUTECPP=OFF, TRISYCL_PACKAGE_ROOT_DIR and COMPUTE_PACKAGE_ROOT_DIR to use the triSYCL mode

Bonus:
    paths are made absolute
    the number of threads used by make is equal to the number of cores (returned by nproc)