### PR TITLE
prevent failure when installing googletests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,9 @@
 # the path to the ComputeCPP package root directory, e.g. /home/user/ComputeCpp-CE-0.1-Linux/
 PACKAGE_ROOT=$1
 
+#compute the number of cores
+NPROC=$(nproc)
+
 function install_gmock  {(
   REPO="git@github.com:google/googletest.git"
   #REPO="https://github.com/google/googletest.git"
@@ -33,7 +36,7 @@ function configure  {
 }
 
 function mak  {
-  pushd build && make -j32
+  pushd build && make -j$NPROC
   popd
 }
 

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,29 @@
 # the path to the ComputeCPP package root directory, e.g. /home/user/ComputeCpp-CE-0.1-Linux/
 PACKAGE_ROOT=$1
 
-function install_gmock  {
-  mkdir -p external && pushd external
-  git clone git@github.com:google/googletest.git
-  pushd googletest/googlemock/make && make
-  popd 
-  popd
-}
+function install_gmock  (
+  REPO="git@github.com:google/googletest.git"
+  #REPO="https://github.com/google/googletest.git"
+  if [ -d external ]
+  then
+    cd external
+    if [ -d googletest ]
+    then
+    (
+      cd googletest
+      git pull
+    )
+    else
+      git clone $REPO
+    fi
+  else
+    mkdir external
+    cd external
+    git clone $REPO
+  fi
+  cd googletest/googlemock/make
+  make
+)
 
 function configure  {
   mkdir -p build && pushd build 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # the path to the ComputeCPP package root directory, e.g. /home/user/ComputeCpp-CE-0.1-Linux/
 PACKAGE_ROOT=$1
 
-function install_gmock  (
+function install_gmock  {(
   REPO="git@github.com:google/googletest.git"
   #REPO="https://github.com/google/googletest.git"
   if [ -d external ]
@@ -23,8 +23,8 @@ function install_gmock  (
     git clone $REPO
   fi
   cd googletest/googlemock/make
-  make
-)
+  make -j$NPROC
+)}
 
 function configure  {
   mkdir -p build && pushd build 

--- a/build.sh
+++ b/build.sh
@@ -8,22 +8,15 @@ NPROC=$(nproc)
 function install_gmock  {(
   REPO="git@github.com:google/googletest.git"
   #REPO="https://github.com/google/googletest.git"
-  if [ -d external ]
+  mkdir -p external
+  cd external
+  if [ -d googletest ]
   then
-    cd external
-    if [ -d googletest ]
-    then
-      cd googletest
-      git pull
-    else
-      git clone $REPO
-      cd googletest
-    fi
+	  cd googletest
+	  git pull
   else
-    mkdir external
-    cd external
-    git clone $REPO
-    cd googletest
+	  git clone $REPO
+	  cd googletest
   fi
   cd googlemock/make
   make -j$NPROC

--- a/build.sh
+++ b/build.sh
@@ -10,19 +10,19 @@ function install_gmock  {(
     cd external
     if [ -d googletest ]
     then
-    (
       cd googletest
       git pull
-    )
     else
       git clone $REPO
+      cd googletest
     fi
   else
     mkdir external
     cd external
     git clone $REPO
+    cd googletest
   fi
-  cd googletest/googlemock/make
+  cd googlemock/make
   make -j$NPROC
 )}
 


### PR DESCRIPTION
I replaced calls to pushd/popd by parenthesis
made the call to multi-threads make
calls git pull to keeps the googletest folder synced with the remote repository

