### PR TITLE
[algorithm/find.hpp] fix of search_result

### DIFF
--- a/include/sycl/algorithm/sort.hpp
+++ b/include/sycl/algorithm/sort.hpp
@@ -115,8 +115,8 @@ class sort_kernel_sequential_comp {
 
   // Simple sequential sort
   void operator()() {
-    for (int i = 0; i < vS_; i++) {
-      for (int j = 1; j < vS_; j++) {
+    for (size_t i = 0; i < vS_; i++) {
+      for (size_t j = 1; j < vS_; j++) {
         if (comp_(a_[j - 1], a_[j])) {
           sort_swap<T>(a_[j - 1], a_[j]);
         }


### PR DESCRIPTION
force the definition of default constructor in search_result, it is needed to initialize t_buf (line 70).