### PR TITLE
Update the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ script:
     # Build parallel-stl
     ###########################
     - if [ "$IMPL" = "TRISYCL" ]; then ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=/tmp/triSYCL-master/include; fi
-    - if [ "$IMPL" = "COMPUTECPP" ]; then COMPUTECPP_TARGET="host" ./build.sh /tmp/ComputeCpp-CE-0.1.4-Linux/; fi
+    - if [ "$IMPL" = "COMPUTECPP" ]; then COMPUTECPP_TARGET="host" ./build.sh /tmp/ComputeCpp-CE-0.2.0-Linux/ -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1; fi
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -6,22 +6,8 @@ set -ev
 sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
 sudo add-apt-repository ppa:kzemek/boost -y
 sudo apt-get update -q
-sudo apt-get install cmake -y
 # TriSYCL requires modern boost
-sudo apt-get install boost1.58 -y
+# Use the system OpenCL loader
+sudo apt-get install cmake boost1.58 ocl-icd-libopencl1 ocl-icd-dev opencl-headers -y
 # Use gcc 5 as default
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
-# Install the khronos stub opencl
-wget https://github.com/KhronosGroup/OpenCL-Headers/archive/master.zip -O /tmp/ocl-headers.zip
-unzip /tmp/ocl-headers.zip -d /tmp
-wget https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/master.zip -O /tmp/ocl-icd.zip
-unzip /tmp/ocl-icd.zip -d /tmp
-ln -sf /tmp/OpenCL-Headers-master/opencl22/CL/ /tmp/OpenCL-ICD-Loader-master/inc/CL
-pushd /tmp/OpenCL-ICD-Loader-master/ && make && popd
-# Recreate a fake OpenCL setup
-sudo mkdir /usr/include/CL/
-sudo cp -Rf /tmp/OpenCL-Headers-master/* /usr/include/CL/
-sudo cp -Rf /tmp/OpenCL-ICD-Loader-master/build/bin/* /usr/lib/
-sudo cp -Rf /tmp/OpenCL-ICD-Loader-master/build/bin/* /usr/lib/x86_64-linux-gnu/
-
-

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.0-Linux/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.0-Linux/include/SYCL/sycl_builtins.h
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.0-Linux/include/CL/sycl_builtins.h.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.0-Linux/include/CL/sycl_builtins.h
-
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.0-Linux/include/CL/host_relational_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.0-Linux/include/CL/host_relational_builtins.h
-
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.0-Linux/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.0-Linux/include/SYCL/host_relational_builtins.h


### PR DESCRIPTION
Recently the Khronos ICD loader was updated, and rather than fix that
this patch uses the standard OpenCL ICD loader and header packages.
It also updates the config to use ComputeCpp 0.2.0, and adds a fix for
the GCC dual ABI (the 14.04 package is built with GCC 4.9, but this
Travis instance uses 5.4). Additionally, it updates the ComputeCpp
workaround file which had some errors.