### PR TITLE
Almost make inner_product compile with sycl buffer

### DIFF
--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -287,7 +287,7 @@ B buffer_map2reduce(ExecutionPolicy &snp,
     cl::sycl::accessor<B, 1, cl::sycl::access::mode::read_write,
                        cl::sycl::access::target::local>
       sum { cl::sycl::range<1>(d.nb_work_item), cgh };
-    cgh.parallel_for_work_group<class wg>(rng, [=](cl::sycl::group<1> grp) {
+    cgh.parallel_for_work_group<class wg>(rng.get_global(), rng.get_local(), [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);
       //assert(group_id < d.nb_work_group);
       size_t group_begin = group_id * d.size_per_work_group;

--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -397,7 +397,6 @@ void buffer_mapscan(ExecutionPolicy &snp,
                        cl::sycl::access::target::local>
       scratch { cl::sycl::range<1> { d.size_per_work_group }, cgh };
 
-
     cgh.parallel_for_work_group<cl::sycl::helpers::NameGen<0, typename ExecutionPolicy::kernelName> >(rng_wg, rng_wi,
                                           [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);

--- a/include/sycl/algorithm/inner_product.hpp
+++ b/include/sycl/algorithm/inner_product.hpp
@@ -177,7 +177,7 @@ T inner_product(ExecutionPolicy &snp, InputIt1 first1, InputIt1 last1,
   auto input_buff1 = sycl::helpers::make_const_buffer(first1, last1);
   auto input_buff2 = sycl::helpers::make_const_buffer(first2, last2);
 
-  auto map = [&](size_t pos, value_type_1 x, value_type_2 y) {
+  auto map = [=](size_t pos, value_type_1 x, value_type_2 y) {
     return op2(x, y);
   };
 

--- a/include/sycl/helpers/sycl_iterator.hpp
+++ b/include/sycl/helpers/sycl_iterator.hpp
@@ -181,6 +181,11 @@ class BufferIterator : public SyclIterator {
     return result;
   }
 
+  BufferIterator<T, Alloc> &operator+=(const int &value) {
+    this->pos_ += value;
+    return (*this);
+  }
+
   // Prefix operator (Increment and return value)
   BufferIterator<T, Alloc> &operator++() {
     this->pos_++;


### PR DESCRIPTION
It doesn't quite compile yet because the execution policy calls inner_product_sequential if the buffer is not a power of 2. The sequential version uses the * operator which is removed for the sycl BufferIterator so it breaks here.
I am not sure what is the cleanest fix for that so I just comment the call to sequential but I don't push that.
I tested the inner_product with small sycl buffers and it works fine.