### PR TITLE
Fixes #35: Build project with CE 0.2.1

### DIFF
--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -30,6 +30,7 @@
 #define __SYCL_IMPL_BUFFER_ALGORITHM__
 
 #include <sycl/helpers/sycl_buffers.hpp>
+#include <sycl/helpers/sycl_namegen.hpp>
 
 namespace sycl {
 namespace impl {
@@ -287,7 +288,8 @@ B buffer_map2reduce(ExecutionPolicy &snp,
     cl::sycl::accessor<B, 1, cl::sycl::access::mode::read_write,
                        cl::sycl::access::target::local>
       sum { cl::sycl::range<1>(d.nb_work_item), cgh };
-    cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(rng, [=](cl::sycl::group<1> grp) {
+    cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(
+        cl::sycl::range<1>{rng.get_global()}, [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);
       //assert(group_id < d.nb_work_group);
       size_t group_begin = group_id * d.size_per_work_group;
@@ -395,7 +397,8 @@ void buffer_mapscan(ExecutionPolicy &snp,
                        cl::sycl::access::target::local>
       scratch { cl::sycl::range<1> { d.size_per_work_group }, cgh };
 
-    cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(rng_wg, rng_wi,
+
+    cgh.parallel_for_work_group<cl::sycl::helpers::NameGen<0, typename ExecutionPolicy::kernelName> >(rng_wg, rng_wi,
                                           [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);
       //assert(group_id < d.nb_work_group);
@@ -509,8 +512,7 @@ void buffer_mapscan(ExecutionPolicy &snp,
       <cl::sycl::access::mode::read_write>(cgh);
     auto read_scan = scan.template get_access
       <cl::sycl::access::mode::read>(cgh);
-
-    cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(rng_wg, rng_wi,
+    cgh.parallel_for_work_group<cl::sycl::helpers::NameGen<1, typename ExecutionPolicy::kernelName>>(rng_wg, rng_wi,
                                           [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);
       B acc = read_scan[group_id];

--- a/include/sycl/algorithm/inner_product.hpp
+++ b/include/sycl/algorithm/inner_product.hpp
@@ -177,7 +177,7 @@ T inner_product(ExecutionPolicy &snp, InputIt1 first1, InputIt1 last1,
   auto input_buff1 = sycl::helpers::make_const_buffer(first1, last1);
   auto input_buff2 = sycl::helpers::make_const_buffer(first2, last2);
 
-  auto map = [&](size_t pos, value_type_1 x, value_type_2 y) {
+  auto map = [=](size_t pos, value_type_1 x, value_type_2 y) {
     return op2(x, y);
   };
 


### PR DESCRIPTION
* Fixed incorrect usage of inner_product in buffer_algorithms

* Fixed missing reference capture in inner_product