### PR TITLE
Implement inner_product_sequential with SYCL

### DIFF
--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -284,7 +284,7 @@ B buffer_map2reduce(ExecutionPolicy &snp,
                        cl::sycl::access::target::local>
       sum { cl::sycl::range<1>(d.nb_work_item), cgh };
     cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(
-        cl::sycl::range<1>{rng.get_global()}, [=](cl::sycl::group<1> grp) {
+        rng.get_global(), rng.get_local(), [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get(0);
       //assert(group_id < d.nb_work_group);
       size_t group_begin = group_id * d.size_per_work_group;

--- a/include/sycl/execution_policy
+++ b/include/sycl/execution_policy
@@ -226,32 +226,14 @@ class sycl_execution_policy {
 
   /* inner_product.
   * @brief Returns the inner product of two vectors across the range [first1,
-  * last1). Implementation of the command group that submits an inner_product
-  * kernel.
-  */
-  template <class InputIt1, class InputIt2, class T>
-  T inner_product(InputIt1 first1, InputIt1 last1, InputIt2 first2, T value) {
-    auto vectorSize = std::distance(first1, last1);
-    if (impl::isPowerOfTwo(vectorSize)) {
-      return impl::inner_product(*this, first1, last1, first2, value,
-                                 [=](T v1, T v2) { return v1 + v2; },
-                                 [=](T v1, T v2) { return v1 * v2; });
-    } else {
-      return impl::inner_product_sequential(*this, first1, last1, first2,
-                                            value);
-    }
-  }
-
-  /* inner_product.
-  * @brief Returns the inner product of two vectors across the range [first1,
   * last1) by applying Functions op1 and op2. Implementation of the command
   * group
   * that submits an inner_product kernel.
   */
-  template <class InputIt1, class InputIt2, class T, class BinaryOperation1,
-            class BinaryOperation2>
+  template <class InputIt1, class InputIt2, class T,
+            class BinaryOperation1 = decltype(std::plus<T>()), class BinaryOperation2 = decltype(std::multiplies<T>())>
   T inner_product(InputIt1 first1, InputIt1 last1, InputIt2 first2, T value,
-                  BinaryOperation1 op1, BinaryOperation2 op2) {
+                  BinaryOperation1 op1 = std::plus<T>(), BinaryOperation2 op2 = std::multiplies<T>()) {
     auto vectorSize = std::distance(first1, last1);
     if (impl::isPowerOfTwo(vectorSize)) {
       return impl::inner_product(*this, first1, last1, first2, value, op1, op2);

--- a/include/sycl/helpers/sycl_iterator.hpp
+++ b/include/sycl/helpers/sycl_iterator.hpp
@@ -181,6 +181,11 @@ class BufferIterator : public SyclIterator {
     return result;
   }
 
+  BufferIterator<T, Alloc> &operator+=(const int &value) {
+    this->pos_ += value;
+    return (*this);
+  }
+
   // Prefix operator (Increment and return value)
   BufferIterator<T, Alloc> &operator++() {
     this->pos_++;


### PR DESCRIPTION
This is a cleaner pull request than my previous one.

The 2 first commits are leftovers from the previous PR.
The first commit add the operator+= needed when std::next is called, the second one use the local range that has been computed.

The third commit is bigger than expected. As I mentioned in the previous PR inner_product didn't compile when using SYCL buffers because it needed to compile inner_product_sequential when the size is not a power of 2. inner_product_sequential only compiled with std iterators because it used the operator*. I added the implementation for SYCL iterators but the hard part was to select which version to use based on the iterators.

I need all this so that my project can use this repository instead of my own fork!