### PR TITLE
Updated ParallelSTL to support SYCL 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+build/
+external/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ script:
     # Build parallel-stl
     ###########################
     - if [ "$IMPL" = "TRISYCL" ]; then ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=/tmp/triSYCL-master/include; fi
-    - if [ "$IMPL" = "COMPUTECPP" ]; then COMPUTECPP_TARGET="host" ./build.sh /tmp/ComputeCpp-latest -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1; fi
+    - if [ "$IMPL" = "COMPUTECPP" ]; then COMPUTECPP_TARGET="host" travis_wait ./build.sh /tmp/ComputeCpp-latest -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1; fi
 

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -6,6 +6,8 @@ set -ev
 # Get ComputeCpp
 ###########################
 wget https://computecpp.codeplay.com/downloads/computecpp-ce/latest/ubuntu-14.04-64bit.tar.gz
-tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp 
+rm -rf /tmp/ComputeCpp-latest && mkdir /tmp/ComputeCpp-latest/
+tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp/ComputeCpp-latest --strip-components 1
+ls -R /tmp/ComputeCpp-latest/
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-VERSION=0.5.0
+cat .travis/additional_undef /tmp/ComputeCpp-latest/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-latest/include/SYCL/sycl_builtins.h
 
-ln -sf /tmp/ComputeCpp-CE-${VERSION}-Linux/ /tmp/ComputeCpp-latest
-
-cat .travis/additional_undef /tmp/ComputeCpp-latest/include/CL/sycl_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-latest/include/CL/sycl_builtins.h.h
-
-cat .travis/additional_undef /tmp/ComputeCpp-latest/include/CL/host_relational_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-latest/include/CL/host_relational_builtins.h
+cat .travis/additional_undef /tmp/ComputeCpp-latest/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-latest/include/SYCL/host_relational_builtins.h
 

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.3.2
+VERSION=0.5.0
 
 ln -sf /tmp/ComputeCpp-CE-${VERSION}-Linux/ /tmp/ComputeCpp-latest
 

--- a/benchmarks/cli_device_selector.hpp
+++ b/benchmarks/cli_device_selector.hpp
@@ -42,7 +42,7 @@ class cli_device_selector : public cl::sycl::device_selector {
   std::string m_device_type;
 
   static cl::sycl::info::device_type match_device_type(std::string requested) {
-    if (requested.empty()) return cl::sycl::info::device_type::defaults;
+    if (requested.empty()) return cl::sycl::info::device_type::automatic;
     std::transform(requested.begin(), requested.end(), requested.begin(),
                    ::tolower);
     if (requested == "gpu") return cl::sycl::info::device_type::gpu;
@@ -51,7 +51,7 @@ class cli_device_selector : public cl::sycl::device_selector {
     if (requested == "*" || requested == "any")
       return cl::sycl::info::device_type::all;
 
-    return cl::sycl::info::device_type::defaults;
+    return cl::sycl::info::device_type::automatic;
   }
 
  public:
@@ -69,7 +69,7 @@ class cli_device_selector : public cl::sycl::device_selector {
     cl::sycl::info::device_type rtype = match_device_type(m_device_type);
     if (rtype == dtype || rtype == cl::sycl::info::device_type::all) {
       score += 2;
-    } else if (rtype == cl::sycl::info::device_type::defaults) {
+    } else if (rtype == cl::sycl::info::device_type::automatic) {
       score += 1;
     } else {
       score -= 2;

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ function mak  {
 
 function tst {
   pushd build/tests
-  ctest -j$NPROC
+  ctest  -VV --timeout 3
   popd
 }
 

--- a/include/experimental/execution_policy
+++ b/include/experimental/execution_policy
@@ -47,27 +47,26 @@ template <class T>
 struct is_execution_policy;
 
 // 2.4 sequential execution policy
-class sequential_execution_policy;
+class sequential_policy;
 
 // 2.5 parallel execution policy
-class parallel_execution_policy;
+class parallel_policy;
 
 // 2.6 vector execution policy
-class vector_execution_policy;
+class parallel_unsequenced_policy;
 
-// 2.7 dynamic execution policy
-class execution_policy;
+class unsequenced_policy;
 
 template <class T>
 struct is_execution_policy
     : integral_constant<bool,
-                        std::is_base_of<sequential_execution_policy,
+                        std::is_base_of<sequential_policy,
                                         typename decay<T>::type>::value ||
-                            std::is_base_of<parallel_execution_policy,
+                            std::is_base_of<parallel_policy,
                                             typename decay<T>::type>::value ||
-                            std::is_base_of<vector_execution_policy,
+                            std::is_base_of<parallel_unsequenced_policy,
                                             typename decay<T>::type>::value ||
-                            std::is_base_of<execution_policy,
+                            std::is_base_of<unsequenced_policy,
                                             typename decay<T>::type>::value> {};
 
 /* execution_policy.
@@ -121,7 +120,7 @@ class execution_policy {
   const type_info *m_typeInfo;
 };
 
-class sequential_execution_policy {
+class sequential_policy {
  public:
   /* sort
    */
@@ -131,7 +130,7 @@ class sequential_execution_policy {
   }
 };
 
-class parallel_execution_policy {
+class parallel_policy {
  public:
   /* sort
    */
@@ -141,7 +140,7 @@ class parallel_execution_policy {
   }
 };
 
-class vector_execution_policy {
+class parallel_unsequenced_policy {
  public:
   /* sort
    */
@@ -151,14 +150,25 @@ class vector_execution_policy {
   }
 };
 
-const sequential_execution_policy seq{};
-const parallel_execution_policy par{};
-const vector_execution_policy vec{};
+class unsequenced_policy {
+ public:
+  /* sort
+   */
+  template <class RandomAccessIterator>
+  inline void sort(RandomAccessIterator b, RandomAccessIterator e) const {
+    std::sort(b, e);
+  }
+};
+
+constexpr sequential_policy seq{};
+constexpr parallel_policy par{};
+constexpr parallel_unsequenced_policy vec{};
+constexpr unsequenced_policy unseq{};
 
 // 2.9 standard execution policy objects
-extern const sequential_execution_policy seq;
-extern const parallel_execution_policy par;
-extern const vector_execution_policy vec;
+extern const sequential_policy seq;
+extern const parallel_policy par;
+extern const parallel_unsequenced_policy vec;
 
 }  // namespace parallel
 }  // namespace experimental

--- a/include/sycl/algorithm/sort.hpp
+++ b/include/sycl/algorithm/sort.hpp
@@ -195,7 +195,7 @@ void bitonic_sort(cl::sycl::queue q, cl::sycl::buffer<T, 1, Alloc> buf,
             cl::sycl::range<1>{r},
             [a, stage, passOfStage](cl::sycl::item<1> it) {
               int sortIncreasing = 1;
-              cl::sycl::id<1> id = it.get();
+              cl::sycl::id<1> id = it.get_id();
               int threadId = id.get(0);
 
               int pairDistance = 1 << (stage - passOfStage);
@@ -256,7 +256,7 @@ void bitonic_sort(cl::sycl::queue q, cl::sycl::buffer<T, 1, Alloc> buf,
             cl::sycl::range<1>{r},
             [a, stage, passOfStage, comp](cl::sycl::item<1> it) {
               int sortIncreasing = 1;
-              cl::sycl::id<1> id = it.get();
+              cl::sycl::id<1> id = it.get_id();
               int threadId = id.get(0);
 
               int pairDistance = 1 << (stage - passOfStage);

--- a/include/sycl/helpers/sycl_buffers.hpp
+++ b/include/sycl/helpers/sycl_buffers.hpp
@@ -110,16 +110,8 @@ template <typename Iterator,
 cl::sycl::buffer<typename std::iterator_traits<Iterator>::value_type, 1>
 make_buffer_impl(Iterator b, Iterator e, std::input_iterator_tag) {
   using type_= typename std::iterator_traits<Iterator>::value_type;
-#ifdef TRISYCL_CL_LANGUAGE_VERSION
   cl::sycl::buffer<type_, 1> buf { b ,e };
   buf.set_final_data(nullptr);
-#else
-  size_t bufferSize = std::distance(b, e);
-  std::unique_ptr<type_> up{new type_[bufferSize]};
-  std::copy(b, e, up.get());
-  cl::sycl::buffer<type_, 1> buf(std::move(up),
-                             cl::sycl::range<1>(bufferSize));
-#endif
   return buf;
 }
 

--- a/tests/buffer_unique_ptr.cpp
+++ b/tests/buffer_unique_ptr.cpp
@@ -52,7 +52,8 @@ TEST_F(UniquePTRAlgorithm, TestSyclUniquePTR) {
   constexpr size_t N = 16;
 
   std::unique_ptr<foo> p(new foo(16, 3.0f));
-  cl::sycl::buffer<foo, 1> a{std::move(p), cl::sycl::range<1>(N)};
+  std::shared_ptr<foo> sP{std::move(p)};
+  cl::sycl::buffer<foo, 1> a{sP, cl::sycl::range<1>(N)};
 
   // After buffer construction, init has been deallocated
   EXPECT_TRUE(!p);

--- a/tests/reduce.cpp
+++ b/tests/reduce.cpp
@@ -47,7 +47,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce) {
   sycl::sycl_execution_policy<class ReduceAlgorithm> snp(q);
   int res = reduce(snp, v.begin(), v.end());
 
-  EXPECT_TRUE(res == result);
+  EXPECT_EQ(res, result);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce2) {
@@ -58,7 +58,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce2) {
   sycl::sycl_execution_policy<class Reduce2Algorithm> snp(q);
   auto res = reduce(snp, v.begin(), v.end(), 10);
 
-  EXPECT_TRUE(res == result[0]);
+  EXPECT_EQ(res, result[0]);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce3) {
@@ -69,7 +69,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce3) {
   sycl::sycl_execution_policy<class Reduce3Algorithm> snp(q);
   auto res = reduce(snp, v.begin(), v.end(), 10);
 
-  EXPECT_TRUE(res == result[0]);
+  EXPECT_EQ(res, result[0]);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce4) {
@@ -81,7 +81,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce4) {
   auto res = reduce(snp, v.begin(), v.end(), 10,
                     [=](int v1, int v2) { return v1 + v2; });
 
-  EXPECT_TRUE(res == result[0]);
+  EXPECT_EQ(res, result[0]);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce5) {
@@ -99,7 +99,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce5) {
   sycl::sycl_execution_policy<class Reduce5Algorithm> snp(q);
   int ressycl = reduce(snp, v.begin(), v.end());
 
-  EXPECT_TRUE(resstd == ressycl);
+  EXPECT_EQ(resstd, ressycl);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce6) {
@@ -117,7 +117,7 @@ TEST_F(ReduceAlgorithm, TestSyclReduce6) {
   sycl::sycl_execution_policy<class Reduce6Algorithm> snp(q);
   int ressycl = reduce(snp, v.begin(), v.end());
 
-  EXPECT_TRUE(resstd == ressycl);
+  EXPECT_EQ(resstd, ressycl);
 }
 
 TEST_F(ReduceAlgorithm, TestSyclReduce7) {
@@ -136,5 +136,5 @@ TEST_F(ReduceAlgorithm, TestSyclReduce7) {
   int ressycl = reduce(snp, v.begin(), v.end(), 10,
                        [=](int val1, int val2) { return val1 + val2; });
 
-  EXPECT_TRUE(resstd == ressycl);
+  EXPECT_EQ(resstd, ressycl);
 }


### PR DESCRIPTION
* Bumped ComputeCpp version to 0.5
* device_type defaults replaced to automatic
* Using iterator constructor instead of unique_ptr one
* Using get_id instead of deprecated id
* Using correct GTest macros for reduction test
* Added gitignore file with vim and cmake build defaults
* Updated names of standard policies to match C++17