### PR TITLE
Issue #16: Optional Intel OpenCL in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ matrix:
   fast_finish: true
 # Some tests are not passing on triSYCL
   allow_failures:
-    - env: IMPL=triSYCL CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=host
-    - env: IMPL=triSYCL CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=host
+    - env: IMPL=COMPUTECPP CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=opencl
+    - env: IMPL=COMPUTECPP CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=opencl
+
 
 before_install:
   - |


### PR DESCRIPTION
Link to Intel OpenCL is not guaranteed to work, so we set
it optional.
Also, making triSYCL host mandatory now that is green.