### PR TITLE
Change methods to inline so as to avoid naming clashes

### DIFF
--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -38,7 +38,7 @@ namespace sycl {
 namespace impl {
 
 
-size_t up_rounded_division(size_t x, size_t y){
+inline size_t up_rounded_division(size_t x, size_t y){
   return (x+(y-1)) / y;
 }
 
@@ -68,7 +68,7 @@ struct sycl_algorithm_descriptor {
  * Compute a valid set of parameters for buffer_mapreduce algorithm to
  * work properly
  */
-sycl_algorithm_descriptor compute_mapreduce_descriptor(cl::sycl::device device,
+inline sycl_algorithm_descriptor compute_mapreduce_descriptor(cl::sycl::device device,
                                                   size_t size,
                                                   size_t sizeofB) {
   using std::max;
@@ -326,7 +326,7 @@ B buffer_map2reduce(ExecutionPolicy &snp,
 
 
 
-sycl_algorithm_descriptor compute_mapscan_descriptor(cl::sycl::device device,
+inline sycl_algorithm_descriptor compute_mapscan_descriptor(cl::sycl::device device,
                                               size_t size,
                                               size_t sizeofB) {
   //std::cout << "size=\t" << size << std::endl;


### PR DESCRIPTION
In some cases, when importing `<sycl/execution_policy>`, a naming clash happens during compilation. Inlining the methods fixes the problem.