### PR TITLE
Update Travis-CI Docker to Ubuntu 17.10, Clang 5 and GCC 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,19 @@ services:
   - docker
 
 env:
-  # - IMPL=triSYCL CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=host
-  - IMPL=triSYCL CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=host
-  - IMPL=COMPUTECPP CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=host
-  - IMPL=COMPUTECPP CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=host
-  - IMPL=COMPUTECPP CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=opencl
-  - IMPL=COMPUTECPP CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=opencl
+  - IMPL=triSYCL CXX_COMPILER=g++-7 CC_COMPILER=gcc-7 TARGET=host
+  - IMPL=triSYCL CXX_COMPILER=clang++-5.0 CC_COMPILER=clang-5.0 TARGET=host
+  - IMPL=COMPUTECPP CXX_COMPILER=g++-7 CC_COMPILER=gcc-7 TARGET=host
+  - IMPL=COMPUTECPP CXX_COMPILER=clang++-5.0 CC_COMPILER=clang-5.0 TARGET=host
+  - IMPL=COMPUTECPP CXX_COMPILER=g++-7 CC_COMPILER=gcc-7 TARGET=opencl
+  - IMPL=COMPUTECPP CXX_COMPILER=clang++-5.0 CC_COMPILER=clang-5.0 TARGET=opencl
 
 matrix:
   fast_finish: true
-# Some tests are not passing on triSYCL
+# Some tests are not passing because of Intel OpenCL download failures
   allow_failures:
-    - env: IMPL=COMPUTECPP CXX_COMPILER=g++-6 CC_COMPILER=gcc-6 TARGET=opencl
-    - env: IMPL=COMPUTECPP CXX_COMPILER=clang++-4.0 CC_COMPILER=clang-4.0 TARGET=opencl
+    - env: IMPL=COMPUTECPP CXX_COMPILER=g++-7 CC_COMPILER=gcc-7 TARGET=opencl
+    - env: IMPL=COMPUTECPP CXX_COMPILER=clang++-5.0 CC_COMPILER=clang-5.0 TARGET=opencl
 
 
 before_install:
@@ -42,4 +42,3 @@ before_install:
 
 script:
   - docker run parallelstl
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:artful
 
 # Default values for the build
 ARG git_branch
@@ -13,21 +13,21 @@ RUN apt-get -yq update
 # Utilities
 RUN apt-get install -yq --allow-downgrades --allow-remove-essential            \
     --allow-change-held-packages git wget apt-utils cmake unzip                \
-    libboost-all-dev software-properties-common python-software-properties libcompute-dev
+    libboost-all-dev software-properties-common python-software-properties
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 RUN apt-get -yq update
 
-# Clang 4.0
-RUN if [ "${c_compiler}" = 'clang-4.0' ]; then apt-get install -yq             \
+# Clang 5.0
+RUN if [ "${c_compiler}" = 'clang-5.0' ]; then apt-get install -yq             \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-     clang-4.0 libomp-dev; fi
+     clang-5.0 libomp-dev; fi
 
-# GCC 6
-RUN if [ "${c_compiler}" = 'gcc-6' ]; then apt-get install -yq                 \
+# GCC 7
+RUN if [ "${c_compiler}" = 'gcc-7' ]; then apt-get install -yq                 \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-    g++-6 gcc-6; fi
+    g++-7 gcc-7; fi
 
 # OpenCL ICD Loader
 RUN apt-get install -yq --allow-downgrades --allow-remove-essential           \

--- a/cmake/Modules/FindTriSYCL.cmake
+++ b/cmake/Modules/FindTriSYCL.cmake
@@ -132,11 +132,11 @@ mark_as_advanced(TRISYCL_DEBUG_STRUCTORS)
 mark_as_advanced(TRISYCL_TRACE_KERNEL)
 
 #triSYCL definitions
-set(CL_SYCL_LANGUAGE_VERSION 220 CACHE VERSION
-  "Host language version to be used by triSYCL (default is: 220)")
-set(TRISYCL_CL_LANGUAGE_VERSION 220 CACHE VERSION
-  "Device language version to be used by triSYCL (default is: 220)")
-set(CMAKE_CXX_STANDARD 14)
+set(CL_SYCL_LANGUAGE_VERSION 121 CACHE VERSION
+  "Host language version to be used by triSYCL (default is: 121)")
+set(TRISYCL_CL_LANGUAGE_VERSION 121 CACHE VERSION
+  "Device language version to be used by triSYCL (default is: 121)")
+set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
 


### PR DESCRIPTION
This is required by the latest triSYCL.
This is a naïve approach since I do not know how to have different Ubuntu versions for ComputeCpp and triSYCL.
So let's try if it breaks ComputeCpp with these versions... :-)