### PR TITLE
Fix max local size

### DIFF
--- a/benchmarks/sycl_reduce.cpp
+++ b/benchmarks/sycl_reduce.cpp
@@ -55,11 +55,11 @@ benchmark<>::time_units_t benchmark_reduce(const unsigned numReps,
 
   cl::sycl::queue q(cds);
   auto device = q.get_device();
-  const auto maxWorkGroupItemSizes =
+  const cl::sycl::id<3> maxWorkItemSizes =
     device.get_info<cl::sycl::info::device::max_work_item_sizes>();
   const auto local = std::min(
       device.get_info<cl::sycl::info::device::max_work_group_size>(),
-      maxWorkGroupItemSizes[0]);
+      maxWorkItemSizes[0]);
   sycl::sycl_execution_policy<class ReduceAlgorithmBench> snp(q);
   auto bufI = sycl::helpers::make_const_buffer(v.begin(), v.end());
   size_t length = N;

--- a/benchmarks/sycl_reduce.cpp
+++ b/benchmarks/sycl_reduce.cpp
@@ -55,9 +55,11 @@ benchmark<>::time_units_t benchmark_reduce(const unsigned numReps,
 
   cl::sycl::queue q(cds);
   auto device = q.get_device();
-  auto local = std::min(
+  const auto maxWorkGroupItemSizes =
+    device.get_info<cl::sycl::info::device::max_work_item_sizes>();
+  const auto local = std::min(
       device.get_info<cl::sycl::info::device::max_work_group_size>(),
-      device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
+      maxWorkGroupItemSizes[0]);
   sycl::sycl_execution_policy<class ReduceAlgorithmBench> snp(q);
   auto bufI = sycl::helpers::make_const_buffer(v.begin(), v.end());
   size_t length = N;

--- a/benchmarks/sycl_reduce.cpp
+++ b/benchmarks/sycl_reduce.cpp
@@ -55,7 +55,9 @@ benchmark<>::time_units_t benchmark_reduce(const unsigned numReps,
 
   cl::sycl::queue q(cds);
   auto device = q.get_device();
-  auto local = device.get_info<cl::sycl::info::device::max_work_group_size>();
+  auto local = std::min(
+      device.get_info<cl::sycl::info::device::max_work_group_size>(),
+      device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
   sycl::sycl_execution_policy<class ReduceAlgorithmBench> snp(q);
   auto bufI = sycl::helpers::make_const_buffer(v.begin(), v.end());
   size_t length = N;

--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -87,10 +87,11 @@ sycl_algorithm_descriptor compute_mapreduce_descriptor(cl::sycl::device device,
   size_t max_work_group =
     device.get_info<cl::sycl::info::device::max_compute_units>();
 
-  //maximal number of work item per work group
-  size_t max_work_item = min(
+  const auto max_work_item_sizes =
+    device.get_info<cl::sycl::info::device::max_work_item_sizes>();
+  const auto max_work_item = min(
     device.get_info<cl::sycl::info::device::max_work_group_size>(),
-    device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
+    max_work_item_sizes[0]);
 
   size_t local_mem_size =
     device.get_info<cl::sycl::info::device::local_mem_size>();
@@ -330,31 +331,26 @@ B buffer_map2reduce(ExecutionPolicy &snp,
 sycl_algorithm_descriptor compute_mapscan_descriptor(cl::sycl::device device,
                                               size_t size,
                                               size_t sizeofB) {
-  //std::cout << "size=\t" << size << std::endl;
   using std::min;
   using std::max;
   if (size == 0)
     return sycl_algorithm_descriptor {};
   size_t local_mem_size =
     device.get_info<cl::sycl::info::device::local_mem_size>();
-  //std::cout << "local_mem_size=\t" << local_mem_size << std::endl;
   size_t size_per_work_group = min(size, local_mem_size / sizeofB);
-  //std::cout << "size_per_work_group=\t" << size_per_work_group << std::endl;
   if (size_per_work_group <= 0)
     return sycl_algorithm_descriptor { size };
 
   size_t nb_work_group = up_rounded_division(size, size_per_work_group);
-  //std::cout << "nb_work_group=\t" << nb_work_group << std::endl;
 
-  size_t max_work_item = min(
+  const auto max_work_item_sizes =
+    device.get_info<cl::sycl::info::device::max_work_item_sizes>();
+  const auto max_work_item = min(
     device.get_info<cl::sycl::info::device::max_work_group_size>(),
-    device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
-  //std::cout << "max_work_item=\t" << max_work_item << std::endl;
+    max_work_item_sizes[0]);
   size_t nb_work_item = min(max_work_item, size_per_work_group);
-  //std::cout << "nb_work_item=\t" << nb_work_item << std::endl;
   size_t size_per_work_item =
     up_rounded_division(size_per_work_group, nb_work_item);
-  //std::cout << "size_per_work_item=\t" << size_per_work_item << std::endl;
   return sycl_algorithm_descriptor {
     size,
     size_per_work_group,

--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -88,8 +88,9 @@ sycl_algorithm_descriptor compute_mapreduce_descriptor(cl::sycl::device device,
     device.get_info<cl::sycl::info::device::max_compute_units>();
 
   //maximal number of work item per work group
-  size_t max_work_item =
-    device.get_info<cl::sycl::info::device::max_work_group_size>();
+  size_t max_work_item = min(
+    device.get_info<cl::sycl::info::device::max_work_group_size>(),
+    device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
 
   size_t local_mem_size =
     device.get_info<cl::sycl::info::device::local_mem_size>();
@@ -345,8 +346,9 @@ sycl_algorithm_descriptor compute_mapscan_descriptor(cl::sycl::device device,
   size_t nb_work_group = up_rounded_division(size, size_per_work_group);
   //std::cout << "nb_work_group=\t" << nb_work_group << std::endl;
 
-  size_t max_work_item =
-    device.get_info<cl::sycl::info::device::max_work_group_size>();
+  size_t max_work_item = min(
+    device.get_info<cl::sycl::info::device::max_work_group_size>(),
+    device.get_info<cl::sycl::info::device::max_work_item_sizes>()[0]);
   //std::cout << "max_work_item=\t" << max_work_item << std::endl;
   size_t nb_work_item = min(max_work_item, size_per_work_group);
   //std::cout << "nb_work_item=\t" << nb_work_item << std::endl;

--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -87,7 +87,7 @@ sycl_algorithm_descriptor compute_mapreduce_descriptor(cl::sycl::device device,
   size_t max_work_group =
     device.get_info<cl::sycl::info::device::max_compute_units>();
 
-  const auto max_work_item_sizes =
+  const cl::sycl::id<3>max_work_item_sizes =
     device.get_info<cl::sycl::info::device::max_work_item_sizes>();
   const auto max_work_item = min(
     device.get_info<cl::sycl::info::device::max_work_group_size>(),
@@ -343,7 +343,7 @@ sycl_algorithm_descriptor compute_mapscan_descriptor(cl::sycl::device device,
 
   size_t nb_work_group = up_rounded_division(size, size_per_work_group);
 
-  const auto max_work_item_sizes =
+  const cl::sycl::id<3> max_work_item_sizes =
     device.get_info<cl::sycl::info::device::max_work_item_sizes>();
   const auto max_work_item = min(
     device.get_info<cl::sycl::info::device::max_work_group_size>(),

--- a/include/sycl/algorithm/count_if.hpp
+++ b/include/sycl/algorithm/count_if.hpp
@@ -63,27 +63,24 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
   }
 
   auto device = q.get_device();
-  auto local =
-      std::min(device.get_info<cl::sycl::info::device::max_work_group_size>(),
-               vectorSize);
   auto bufI = sycl::helpers::make_const_buffer(first, last);
   cl::sycl::buffer<int, 1> bufR((cl::sycl::range<1>(vectorSize)));
-  size_t length = exec.calculateGlobalSize(vectorSize, local);
+  size_t length = vectorSize;
+  auto ndRange = exec.calculateNdRange(vectorSize);
+  const auto local = ndRange.get_local()[0];
   int passes = 0;
 
   do {
-    auto f = [length, local, passes, &bufI, &bufR, unary_op, binary_op](
+    auto f = [passes, length, ndRange, local, &bufI, &bufR, unary_op, binary_op](
         cl::sycl::handler& h) mutable {
-      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(length, local)},
-                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read>(h);
       auto aR = bufR.template get_access<cl::sycl::access::mode::read_write>(h);
       cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::local>
-          scratch(cl::sycl::range<1>(local), h);
+          scratch(ndRange.get_local(), h);
 
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [aI, aR, scratch, local, length, passes, unary_op, binary_op](
+          ndRange, [aI, aR, scratch, passes, local, length, unary_op, binary_op](
                  cl::sycl::nd_item<1> id) {
             auto r = ReductionStrategy<int>(local, length, id, scratch);
             if (passes == 0) {
@@ -97,6 +94,8 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
     };         // end command group
     q.submit(f);
     length = length / local;
+    ndRange = cl::sycl::nd_range<1>{cl::sycl::range<1>(std::max(length, local)),
+                                    ndRange.get_local()};
     passes++;
   } while (length > 1);
   q.wait_and_throw();

--- a/include/sycl/algorithm/equal.hpp
+++ b/include/sycl/algorithm/equal.hpp
@@ -67,7 +67,7 @@ bool equal(ExecutionPolicy& exec, ForwardIt1 first1, ForwardIt1 last1,
 
   auto device = q.get_device();
 
-  size_t length = size1;
+  auto length = size1;
   auto ndRange = exec.calculateNdRange(size1);
   const auto local = ndRange.get_local()[0];
 

--- a/include/sycl/algorithm/fill.hpp
+++ b/include/sycl/algorithm/fill.hpp
@@ -47,21 +47,16 @@ template <typename ExecutionPolicy, typename ForwardIt, typename T>
 void fill(ExecutionPolicy &sep, ForwardIt b, ForwardIt e, const T &value) {
   cl::sycl::queue q { sep.get_queue() };
   auto device = q.get_device();
-  size_t localRange =
-    device.get_info<cl::sycl::info::device::max_work_group_size>();
   auto bufI = helpers::make_buffer( b, e );
   // copy value into a local variable, as we cannot capture it by reference
   T val = value;
   auto vectorSize = bufI.get_count();
-  size_t globalRange = sep.calculateGlobalSize(vectorSize, localRange);
-  auto f = [vectorSize, localRange, globalRange, &bufI, val](
+  const auto ndRange = sep.calculateNdRange(vectorSize);
+  auto f = [vectorSize, ndRange, &bufI, val](
       cl::sycl::handler &h) mutable {
-    cl::sycl::nd_range<1> r{
-        cl::sycl::range<1>{std::max(globalRange, localRange)},
-        cl::sycl::range<1>{localRange}};
     auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
-        r, [aI, val, vectorSize](cl::sycl::nd_item<1> id) {
+        ndRange, [aI, val, vectorSize](cl::sycl::nd_item<1> id) {
           if (id.get_global(0) < vectorSize) {
             aI[id.get_global(0)] = val;
           }

--- a/include/sycl/algorithm/for_each_n.hpp
+++ b/include/sycl/algorithm/for_each_n.hpp
@@ -57,18 +57,14 @@ InputIterator for_each_n(ExecutionPolicy &exec, InputIterator first, Size n,
   if (n > 0) {
     auto last(first + n);
     auto device = q.get_device();
-    size_t local =
-        device.get_info<cl::sycl::info::device::max_work_group_size>();
     auto bufI = sycl::helpers::make_buffer(first, last);
     auto vectorSize = bufI.get_count();
-    size_t global = exec.calculateGlobalSize(vectorSize, local);
-    auto cg = [vectorSize, local, global, &bufI, f](
+    const auto ndRange = exec.calculateNdRange(vectorSize);
+    auto cg = [vectorSize, ndRange, &bufI, f](
         cl::sycl::handler &h) mutable {
-      cl::sycl::nd_range<1> r{cl::sycl::range<1>{std::max(global, local)},
-                              cl::sycl::range<1>{local}};
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
-          r, [vectorSize, aI, f](cl::sycl::nd_item<1> id) {
+          ndRange, [vectorSize, aI, f](cl::sycl::nd_item<1> id) {
             if (id.get_global(0) < vectorSize) {
               f(aI[id.get_global(0)]);
             }

--- a/include/sycl/algorithm/replace_if.hpp
+++ b/include/sycl/algorithm/replace_if.hpp
@@ -54,19 +54,13 @@ void replace_if(ExecutionPolicy &sep, ForwardIt first, ForwardIt last,
   const T new_val = new_value;
 
   const auto vectorSize = bufI.get_count();
-  const auto localRange =
-      device.get_info<cl::sycl::info::device::max_work_group_size>();
-  const auto globalRange = sep.calculateGlobalSize(vectorSize, localRange);
+  const auto ndRange = sep.calculateNdRange(vectorSize);
 
-  const auto f = [vectorSize, p, new_val, localRange, globalRange,
+  const auto f = [vectorSize, p, new_val, ndRange,
             &bufI](cl::sycl::handler &h) mutable {
-    cl::sycl::nd_range<1> r{
-        cl::sycl::range<1>{std::max(globalRange, localRange)},
-        cl::sycl::range<1>{localRange}};
-
     const auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
-        r, [aI, vectorSize, p, new_val](cl::sycl::nd_item<1> id) {
+        ndRange, [aI, vectorSize, p, new_val](cl::sycl::nd_item<1> id) {
           const auto global_id = id.get_global(0);
           if (global_id < vectorSize) {
             if(p(aI[global_id])) {

--- a/include/sycl/execution_policy
+++ b/include/sycl/execution_policy
@@ -104,10 +104,12 @@ class sycl_execution_policy {
   */
   cl::sycl::nd_range<1> calculateNdRange(size_t problemSize) {
     const auto& d = m_q.get_device();
-    size_t localSize = std::min(problemSize,
+    const cl::sycl::id<3> maxWorkItemSizes =
+      d.template get_info<cl::sycl::info::device::max_work_item_sizes>();
+    const auto localSize = std::min(problemSize,
         std::min(
           d.template get_info<cl::sycl::info::device::max_work_group_size>(),
-          d.template get_info<cl::sycl::info::device::max_work_item_sizes>()[0]
+          maxWorkItemSizes[0]
         ));
 
     size_t globalSize;

--- a/include/sycl/execution_policy
+++ b/include/sycl/execution_policy
@@ -98,22 +98,27 @@ class sycl_execution_policy {
   // Returns the queue, if any
   cl::sycl::queue get_queue() const { return m_q; }
 
-  /* Calculate GlobalSize.
-  * @brief Calculates a divisible global size
-  * @param global : The problem size
-  * @param local  : The local size
+  /* Calculate NdRange.
+  * @brief Calculates an nd_range with a global size divisable by problemSize
+  * @param problemSize : The problem size
   */
-  std::size_t calculateGlobalSize(std::size_t global, std::size_t local) {
-    std::size_t newGlobal = 0;
+  cl::sycl::nd_range<1> calculateNdRange(size_t problemSize) {
+    const auto& d = m_q.get_device();
+    size_t localSize = std::min(problemSize,
+        std::min(
+          d.template get_info<cl::sycl::info::device::max_work_group_size>(),
+          d.template get_info<cl::sycl::info::device::max_work_item_sizes>()[0]
+        ));
 
-    if (global % local == 0) {
-      newGlobal = global;
+    size_t globalSize;
+    if (problemSize % localSize == 0) {
+      globalSize = problemSize;
     } else {
-      newGlobal = global / local;
-      newGlobal = (newGlobal + 1) * local;
+      globalSize = (problemSize / localSize + 1) * localSize;
     }
 
-    return newGlobal;
+    return cl::sycl::nd_range<1>{cl::sycl::range<1>{globalSize},
+                                 cl::sycl::range<1>{localSize}};
   }
 
   /** reduce


### PR DESCRIPTION
I had an issue with a device that has:
```
Max work item sizes                             256x256x256
Max work group size                             384
```
because SyclParallelSTL assumes that `max_work_group_size <= max_work_item_sizes[i]`

Main noticeable changes are:
* for some algorithm the local size can now be smaller than `max_work_group_size ` if `vectorSize < max_work_group_size`
* public method `sycl_policy::calcultateGlobalSize` no longer exists though I believe it should only be used internally.