### PR TITLE
Applied SYCL 1.2.1 renamed member functions for `nd_item` and `nd_range`

### DIFF
--- a/include/sycl/algorithm/algorithm_composite_patterns.hpp
+++ b/include/sycl/algorithm/algorithm_composite_patterns.hpp
@@ -57,8 +57,8 @@ class ReductionStrategy {
  public:
   ReductionStrategy(int loc, int len, cl::sycl::nd_item<1> i,
                     const local_rw_acc<T>& localmem)
-      : localid_(i.get_local(0)),
-        globalid_(i.get_global(0)),
+      : localid_(i.get_local_id(0)),
+        globalid_(i.get_global_id(0)),
         local_(loc),
         length_(len),
         id_(i),

--- a/include/sycl/algorithm/buffer_algorithms.hpp
+++ b/include/sycl/algorithm/buffer_algorithms.hpp
@@ -286,7 +286,7 @@ B buffer_map2reduce(ExecutionPolicy &snp,
                        cl::sycl::access::target::local>
       sum { cl::sycl::range<1>(d.nb_work_item), cgh };
     cgh.parallel_for_work_group<typename ExecutionPolicy::kernelName>(
-        rng.get_global(), rng.get_local(), [=](cl::sycl::group<1> grp) {
+        rng.get_global_range(), rng.get_local_range(), [=](cl::sycl::group<1> grp) {
       size_t group_id = grp.get_id(0);
       //assert(group_id < d.nb_work_group);
       size_t group_begin = group_id * d.size_per_work_group;

--- a/include/sycl/algorithm/count_if.hpp
+++ b/include/sycl/algorithm/count_if.hpp
@@ -67,7 +67,7 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
   cl::sycl::buffer<int, 1> bufR((cl::sycl::range<1>(vectorSize)));
   auto length = vectorSize;
   auto ndRange = exec.calculateNdRange(vectorSize);
-  const auto local = ndRange.get_local()[0];
+  const auto local = ndRange.get_local_range()[0];
   int passes = 0;
 
   auto f = [&passes, &length, &ndRange, local, &bufI, &bufR, unary_op, binary_op](
@@ -76,7 +76,7 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
     auto aR = bufR.template get_access<cl::sycl::access::mode::read_write>(h);
     cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write,
                        cl::sycl::access::target::local>
-        scratch(ndRange.get_local(), h);
+        scratch(ndRange.get_local_range(), h);
 
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, aR, scratch, passes, local, length, unary_op, binary_op](
@@ -95,7 +95,7 @@ typename std::iterator_traits<InputIterator>::difference_type count_if(
     q.submit(f);
     length = length / local;
     ndRange = cl::sycl::nd_range<1>{cl::sycl::range<1>(std::max(length, local)),
-                                    ndRange.get_local()};
+                                    ndRange.get_local_range()};
     passes++;
   } while (length > 1);
   q.wait_and_throw();

--- a/include/sycl/algorithm/equal.hpp
+++ b/include/sycl/algorithm/equal.hpp
@@ -69,7 +69,7 @@ bool equal(ExecutionPolicy& exec, ForwardIt1 first1, ForwardIt1 last1,
 
   auto length = size1;
   auto ndRange = exec.calculateNdRange(size1);
-  const auto local = ndRange.get_local()[0];
+  const auto local = ndRange.get_local_range()[0];
 
   auto buf1 = sycl::helpers::make_const_buffer(first1, last1);
   auto buf2 = sycl::helpers::make_const_buffer(first2, last2);
@@ -85,7 +85,7 @@ bool equal(ExecutionPolicy& exec, ForwardIt1 first1, ForwardIt1 last1,
       auto aR = bufR.template get_access<cl::sycl::access::mode::read_write>(h);
       cl::sycl::accessor<bool, 1, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::local>
-          scratch(ndRange.get_local(), h);
+          scratch(ndRange.get_local_range(), h);
 
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           ndRange, [a1, a2, aR, scratch, passes, local, length,
@@ -105,7 +105,7 @@ bool equal(ExecutionPolicy& exec, ForwardIt1 first1, ForwardIt1 last1,
     q.submit(f);
     length = length / local;
     ndRange = cl::sycl::nd_range<1>{cl::sycl::range<1>(std::max(length, local)),
-                                    ndRange.get_local()};
+                                    ndRange.get_local_range()};
     ++passes;
   } while (length > 1);
   q.wait_and_throw();

--- a/include/sycl/algorithm/exclusive_scan.hpp
+++ b/include/sycl/algorithm/exclusive_scan.hpp
@@ -82,7 +82,7 @@ OutputIterator exclusive_scan(ExecutionPolicy &sep, InputIterator b,
     h.parallel_for<
         cl::sycl::helpers::NameGen<0, typename ExecutionPolicy::kernelName> >(
         ndRange, [aI, aO, init, vectorSize](cl::sycl::nd_item<1> id) {
-          size_t m_id = id.get_global(0);
+          size_t m_id = id.get_global_id(0);
           if (m_id > 0) {
             aO[m_id] = aI[m_id - 1];
           } else {
@@ -106,7 +106,7 @@ OutputIterator exclusive_scan(ExecutionPolicy &sep, InputIterator b,
           cl::sycl::helpers::NameGen<1, typename ExecutionPolicy::kernelName> >(
           ndRange, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<1> id) {
             size_t td = 1 << (i - 1);
-            size_t m_id = id.get_global(0);
+            size_t m_id = id.get_global_id(0);
             if (m_id < vectorSize && m_id >= td) {
               aO[m_id] = bop(aI[m_id - td], aI[m_id]);
             } else {

--- a/include/sycl/algorithm/fill.hpp
+++ b/include/sycl/algorithm/fill.hpp
@@ -57,8 +57,8 @@ void fill(ExecutionPolicy &sep, ForwardIt b, ForwardIt e, const T &value) {
     auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, val, vectorSize](cl::sycl::nd_item<1> id) {
-          if (id.get_global(0) < vectorSize) {
-            aI[id.get_global(0)] = val;
+          if (id.get_global_id(0) < vectorSize) {
+            aI[id.get_global_id(0)] = val;
           }
         });
   };

--- a/include/sycl/algorithm/for_each.hpp
+++ b/include/sycl/algorithm/for_each.hpp
@@ -56,8 +56,8 @@ void for_each(ExecutionPolicy &sep, Iterator b, Iterator e, UnaryFunction op) {
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           ndRange, [aI, op, vectorSize](cl::sycl::nd_item<1> id) {
-            if (id.get_global(0) < vectorSize) {
-              op(aI[id.get_global(0)]);
+            if (id.get_global_id(0) < vectorSize) {
+              op(aI[id.get_global_id(0)]);
             }
           });
     };

--- a/include/sycl/algorithm/for_each_n.hpp
+++ b/include/sycl/algorithm/for_each_n.hpp
@@ -65,8 +65,8 @@ InputIterator for_each_n(ExecutionPolicy &exec, InputIterator first, Size n,
       auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           ndRange, [vectorSize, aI, f](cl::sycl::nd_item<1> id) {
-            if (id.get_global(0) < vectorSize) {
-              f(aI[id.get_global(0)]);
+            if (id.get_global_id(0) < vectorSize) {
+              f(aI[id.get_global_id(0)]);
             }
           });
     };

--- a/include/sycl/algorithm/generate.hpp
+++ b/include/sycl/algorithm/generate.hpp
@@ -59,8 +59,8 @@ void generate(ExecutionPolicy &sep, ForwardIt first, ForwardIt last,
     const auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, g, vectorSize](cl::sycl::nd_item<1> id) {
-          if (id.get_global(0) < vectorSize) {
-            aI[id.get_global(0)] = g();
+          if (id.get_global_id(0) < vectorSize) {
+            aI[id.get_global_id(0)] = g();
           }
         });
   };

--- a/include/sycl/algorithm/inclusive_scan.hpp
+++ b/include/sycl/algorithm/inclusive_scan.hpp
@@ -86,7 +86,7 @@ OutputIterator inclusive_scan(ExecutionPolicy &sep, InputIterator b,
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           ndRange, [aI, aO, bop, vectorSize, i](cl::sycl::nd_item<1> id) {
             size_t td = 1 << (i - 1);
-            size_t m_id = id.get_global(0);
+            size_t m_id = id.get_global_id(0);
 
             if (m_id < vectorSize && m_id >= td) {
               aO[m_id] = bop(aI[m_id - td], aI[m_id]);

--- a/include/sycl/algorithm/replace_copy_if.hpp
+++ b/include/sycl/algorithm/replace_copy_if.hpp
@@ -68,7 +68,7 @@ ForwardIt2 replace_copy_if(ExecutionPolicy &sep, ForwardIt1 first,
     const auto aO = bufO.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, aO, vectorSize, p, new_val](cl::sycl::nd_item<1> id) {
-          const auto global_id = id.get_global(0);
+          const auto global_id = id.get_global_id(0);
           const auto orig_value = aI[global_id];
           if (global_id < vectorSize) {
             if (p(orig_value)) {

--- a/include/sycl/algorithm/replace_if.hpp
+++ b/include/sycl/algorithm/replace_if.hpp
@@ -61,7 +61,7 @@ void replace_if(ExecutionPolicy &sep, ForwardIt first, ForwardIt last,
     const auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, vectorSize, p, new_val](cl::sycl::nd_item<1> id) {
-          const auto global_id = id.get_global(0);
+          const auto global_id = id.get_global_id(0);
           if (global_id < vectorSize) {
             if(p(aI[global_id])) {
               aI[global_id] = new_val;

--- a/include/sycl/algorithm/reverse.hpp
+++ b/include/sycl/algorithm/reverse.hpp
@@ -57,7 +57,7 @@ void reverse(ExecutionPolicy &sep, BidirIt first, BidirIt last) {
     const auto aI = bufI.template get_access<cl::sycl::access::mode::read_write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, vectorSize](cl::sycl::nd_item<1> id) {
-          const auto global_id = id.get_global(0);
+          const auto global_id = id.get_global_id(0);
           if (global_id < vectorSize / 2) {
             helpers::swap(aI[global_id], aI[vectorSize - global_id - 1]);
           }

--- a/include/sycl/algorithm/reverse_copy.hpp
+++ b/include/sycl/algorithm/reverse_copy.hpp
@@ -61,7 +61,7 @@ ForwardIt reverse_copy(ExecutionPolicy &sep, BidirIt first, BidirIt last,
     const auto aO = bufO.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [aI, aO, vectorSize](cl::sycl::nd_item<1> id) {
-          const auto global_id = id.get_global(0);
+          const auto global_id = id.get_global_id(0);
           if (global_id < vectorSize) {
             aO[global_id] = aI[vectorSize - global_id - 1];
           }

--- a/include/sycl/algorithm/transform.hpp
+++ b/include/sycl/algorithm/transform.hpp
@@ -65,8 +65,8 @@ OutputIterator transform(ExecutionPolicy &sep, Iterator b, Iterator e,
       auto aO = bufO.template get_access<cl::sycl::access::mode::write>(h);
       h.parallel_for<typename ExecutionPolicy::kernelName>(
           ndRange, [aI, aO, op, vectorSize](cl::sycl::nd_item<1> id) {
-            if ((id.get_global(0) < vectorSize)) {
-              aO[id.get_global(0)] = op(aI[id.get_global(0)]);
+            if ((id.get_global_id(0) < vectorSize)) {
+              aO[id.get_global_id(0)] = op(aI[id.get_global_id(0)]);
             }
           });
     };
@@ -104,9 +104,9 @@ OutputIterator transform(ExecutionPolicy &sep, InputIterator first1,
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
-          if (id.get_global(0) < n) {
-            aO[id.get_global(0)] =
-                op(a1[id.get_global(0)], a2[id.get_global(0)]);
+          if (id.get_global_id(0) < n) {
+            aO[id.get_global_id(0)] =
+                op(a1[id.get_global_id(0)], a2[id.get_global_id(0)]);
           }
         });
   };
@@ -144,9 +144,9 @@ OutputIterator transform(ExecutionPolicy &sep, cl::sycl::queue &q,
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<typename ExecutionPolicy::kernelName>(
         ndRange, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
-          if (id.get_global(0) < n) {
-            aO[id.get_global(0)] =
-                op(a1[id.get_global(0)], a2[id.get_global(0)]);
+          if (id.get_global_id(0) < n) {
+            aO[id.get_global_id(0)] =
+                op(a1[id.get_global_id(0)], a2[id.get_global_id(0)]);
           }
         });
   };
@@ -177,9 +177,9 @@ void transform(ExecutionPolicy &sep, cl::sycl::queue &q, Buffer &buf1,
     auto aO = res.template get_access<cl::sycl::access::mode::write>(h);
     h.parallel_for<class TransformAlgorithm>(
         ndRange, [a1, a2, aO, op, n](cl::sycl::nd_item<1> id) {
-          if (id.get_global(0) < n) {
-            aO[id.get_global(0)] =
-                op(a1[id.get_global(0)], a2[id.get_global(0)]);
+          if (id.get_global_id(0) < n) {
+            aO[id.get_global_id(0)] =
+                op(a1[id.get_global_id(0)], a2[id.get_global_id(0)]);
           }
         });
   };


### PR DESCRIPTION
* `nd_item::get_local` -> `nd_item::get_local_id`
* `nd_item::get_global` -> `nd_item::get_global_id`
* `nd_range::get_local` -> `nd_range::get_local_range`
* `nd_range::get_global` -> `nd_range::get_global_range`