### PR TITLE
Update benchmarks with new member function names from nd_item to match SYCL 1.2.1 rev 3

### DIFF
--- a/benchmarks/nbody.cpp
+++ b/benchmarks/nbody.cpp
@@ -157,9 +157,9 @@ benchmark<>::time_units_t benchmark_nbody(const unsigned numReps,
           d_bodies.get_access<cl::sycl::access::mode::read_write>(h);
       h.parallel_for<class NBodyAlgorithm>(
           ndRange, [a_bodies, vectorSize](cl::sycl::nd_item<1> id) {
-            if (id.get_global(0) < vectorSize) {
+            if (id.get_global_id(0) < vectorSize) {
               for (size_t i = 0; i < vectorSize; i++) {
-                a_bodies[id.get_global(0)].addForce(a_bodies[i]);
+                a_bodies[id.get_global_id(0)].addForce(a_bodies[i]);
               }
             }
           });

--- a/benchmarks/sycl_reduce.cpp
+++ b/benchmarks/sycl_reduce.cpp
@@ -77,8 +77,8 @@ benchmark<>::time_units_t benchmark_reduce(const unsigned numReps,
 
         h.parallel_for<class ReduceAlgorithmBench>(
             r, [aI, scratch, local, length](cl::sycl::nd_item<1> id) {
-              size_t globalid = id.get_global(0);
-              size_t localid = id.get_local(0);
+              size_t globalid = id.get_global_id(0);
+              size_t localid = id.get_local_id(0);
 
               if (globalid < length) {
                 scratch[localid] = aI[globalid];


### PR DESCRIPTION
That is strange, it looks like Travis-CI does not check the compilation of the benchmarks, otherwise this would have been detected...

If you agree with my analysis, please open an issue about this.