### PR TITLE
Fixed: Size of vector checked after buffer construction

### DIFF
--- a/include/sycl/algorithm/transform_reduce.hpp
+++ b/include/sycl/algorithm/transform_reduce.hpp
@@ -57,10 +57,12 @@ T transform_reduce(ExecutionPolicy& exec, InputIterator first,
                    BinaryOperation binary_op) {
   cl::sycl::queue q(exec.get_queue());
   auto vectorSize = sycl::helpers::distance(first, last);
-  cl::sycl::buffer<T, 1> bufR((cl::sycl::range<1>(vectorSize)));
+  
   if (vectorSize < 1) {
     return init;
   }
+
+  cl::sycl::buffer<T, 1> bufR((cl::sycl::range<1>(vectorSize)));
 
   auto device = q.get_device();
   auto bufI = sycl::helpers::make_const_buffer(first, last);


### PR DESCRIPTION
When testing a buffer of invalid size, SYCL buffer throws an
invalid buffer exception.
However, the STL interface should not throw if the size is invalid,
just do a no operation.

This patch reorders the buffer constructor and the vector size check
to ensures invalid SYCL buffers are not created.