### PR TITLE
WIP: Re-implement sort() as merge sort

### DIFF
--- a/include/sycl/execution_policy
+++ b/include/sycl/execution_policy
@@ -181,7 +181,10 @@ class sycl_execution_policy {
     if (impl::isPowerOfTwo(vectorSize)) {
       sycl::impl::bitonic_sort<type_>(q, buf, vectorSize);
     } else {
-      sycl::impl::sequential_sort<type_>(q, buf, vectorSize);
+      auto lTempBuf = std::move(sycl::helpers::make_buffer(b, e));
+      auto rTempBuf = std::move(sycl::helpers::make_buffer(b, e));
+      sycl::impl::sequential_sort<type_>(q, buf, lTempBuf, rTempBuf,
+                                         vectorSize);
     }
   }
 


### PR DESCRIPTION
Re-implements sequential_sort() as merge sort to address original implementation's poor performance (n^2) on large size vectors.

For large (e.g. > 1,000,000) size vectors, this new implementation will outperform std::sort(), however in the case of smaller vectors, std::sort() will outperform it. It will overall beat out the original SyclParallelSTL sort implementation due to being n*log(n).

This PR is WIP, it needs generalising for sequential_sort_comp, however I'd like code review so I can fix any issues before generalising - another potential issue is the use of 3 buffers rather than one, which act as the merge sort's sublists, tripling memory usage.

See [original issue](https://github.com/KhronosGroup/SyclParallelSTL/issues/90) for more information.